### PR TITLE
feat: add multi-language (i18n) support with EN, ES, FR, DE translations

### DIFF
--- a/resources/lang/de/commands.php
+++ b/resources/lang/de/commands.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    'install' => [
+        'installing' => 'Escalated wird installiert...',
+        'publishing_config' => 'Konfiguration wird veröffentlicht',
+        'publishing_migrations' => 'Migrationen werden veröffentlicht',
+        'publishing_views' => 'E-Mail-Ansichten werden veröffentlicht',
+        'installing_npm' => 'npm-Paket wird installiert',
+        'npm_manual' => 'npm-Paket konnte nicht automatisch installiert werden. Führen Sie manuell aus:',
+        'success' => 'Escalated erfolgreich installiert!',
+        'next_steps' => 'Nächste Schritte:',
+        'step1' => '1. Implementieren Sie das Ticketable-Interface in Ihrem User-Modell:',
+        'step2' => '2. Definieren Sie Autorisierungs-Gates in Ihrem AuthServiceProvider:',
+        'step3' => '3. Führen Sie die Migrationen aus:',
+        'step4' => '4. Fügen Sie Escalated-Seiten zur Tailwind-Inhaltskonfiguration hinzu:',
+        'step5' => '5. Fügen Sie den Inertia-Seitenresolver und das Plugin in Ihrer app.ts hinzu:',
+        'step6' => '6. Besuchen Sie /support, um das Kundenportal zu sehen',
+    ],
+
+];

--- a/resources/lang/de/emails.php
+++ b/resources/lang/de/emails.php
@@ -1,0 +1,82 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'heading' => 'Neues Support-Ticket',
+        'intro' => 'Ein neues Support-Ticket wurde erstellt.',
+        'reference_label' => 'Referenz',
+        'subject_label' => 'Betreff',
+        'priority_label' => 'Priorität',
+        'button' => 'Ticket ansehen',
+        'thanks' => 'Vielen Dank',
+    ],
+
+    'assigned' => [
+        'heading' => 'Ticket Ihnen zugewiesen',
+        'intro' => 'Ihnen wurde ein Support-Ticket zugewiesen.',
+        'reference_label' => 'Referenz',
+        'subject_label' => 'Betreff',
+        'priority_label' => 'Priorität',
+        'status_label' => 'Status',
+        'button' => 'Ticket ansehen',
+        'closing' => 'Bitte überprüfen und antworten Sie so bald wie möglich.',
+        'thanks' => 'Vielen Dank',
+    ],
+
+    'reply' => [
+        'heading' => 'Neue Antwort zu :reference',
+        'intro' => 'Eine neue Antwort wurde zu Ihrem Support-Ticket hinzugefügt.',
+        'subject_label' => 'Betreff',
+        'button' => 'Ticket ansehen',
+        'thanks' => 'Vielen Dank',
+    ],
+
+    'resolved' => [
+        'heading' => 'Ticket gelöst',
+        'intro' => 'Ihr Support-Ticket wurde gelöst.',
+        'reference_label' => 'Referenz',
+        'subject_label' => 'Betreff',
+        'reopen_note' => 'Wenn Sie weitere Hilfe benötigen, können Sie dieses Ticket erneut öffnen.',
+        'button' => 'Ticket ansehen',
+        'thanks' => 'Vielen Dank',
+    ],
+
+    'status_changed' => [
+        'heading' => 'Ticket-Status aktualisiert',
+        'intro' => 'Der Status Ihres Support-Tickets wurde aktualisiert.',
+        'reference_label' => 'Referenz',
+        'subject_label' => 'Betreff',
+        'previous_status_label' => 'Vorheriger Status',
+        'new_status_label' => 'Neuer Status',
+        'button' => 'Ticket ansehen',
+        'thanks' => 'Vielen Dank',
+    ],
+
+    'escalated' => [
+        'heading' => 'Ticket eskaliert',
+        'intro' => 'Ein Support-Ticket wurde eskaliert.',
+        'reference_label' => 'Referenz',
+        'subject_label' => 'Betreff',
+        'priority_label' => 'Priorität',
+        'reason_label' => 'Grund',
+        'attention_note' => 'Sofortige Aufmerksamkeit ist erforderlich.',
+        'button' => 'Ticket ansehen',
+        'thanks' => 'Vielen Dank',
+    ],
+
+    'sla_breach' => [
+        'heading' => 'SLA-Verletzungswarnung',
+        'intro' => 'Ein SLA wurde bei einem Support-Ticket verletzt.',
+        'reference_label' => 'Referenz',
+        'subject_label' => 'Betreff',
+        'priority_label' => 'Priorität',
+        'breach_type_label' => 'Verletzungstyp',
+        'first_response' => 'Erste Antwort',
+        'resolution' => 'Lösung',
+        'attention_note' => 'Sofortige Aufmerksamkeit ist erforderlich.',
+        'button' => 'Ticket ansehen',
+        'thanks' => 'Vielen Dank',
+    ],
+
+];

--- a/resources/lang/de/enums.php
+++ b/resources/lang/de/enums.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    'status' => [
+        'open' => 'Offen',
+        'in_progress' => 'In Bearbeitung',
+        'waiting_on_customer' => 'Warten auf Kunde',
+        'waiting_on_agent' => 'Warten auf Mitarbeiter',
+        'escalated' => 'Eskaliert',
+        'resolved' => 'Gelöst',
+        'closed' => 'Geschlossen',
+        'reopened' => 'Wiedereröffnet',
+    ],
+
+    'priority' => [
+        'low' => 'Niedrig',
+        'medium' => 'Mittel',
+        'high' => 'Hoch',
+        'urgent' => 'Dringend',
+        'critical' => 'Kritisch',
+    ],
+
+    'activity_type' => [
+        'status_changed' => 'Status geändert',
+        'assigned' => 'Zugewiesen',
+        'unassigned' => 'Zuweisung aufgehoben',
+        'priority_changed' => 'Priorität geändert',
+        'tag_added' => 'Tag hinzugefügt',
+        'tag_removed' => 'Tag entfernt',
+        'escalated' => 'Eskaliert',
+        'sla_breached' => 'SLA verletzt',
+        'replied' => 'Beantwortet',
+        'note_added' => 'Notiz hinzugefügt',
+        'department_changed' => 'Abteilung geändert',
+        'reopened' => 'Wiedereröffnet',
+        'resolved' => 'Gelöst',
+        'closed' => 'Geschlossen',
+    ],
+
+];

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -1,0 +1,103 @@
+<?php
+
+return [
+
+    'ticket' => [
+        'reply_sent' => 'Antwort gesendet.',
+        'note_added' => 'Notiz hinzugefügt.',
+        'assigned' => 'Ticket zugewiesen.',
+        'status_updated' => 'Status aktualisiert.',
+        'priority_updated' => 'Priorität aktualisiert.',
+        'tags_updated' => 'Tags aktualisiert.',
+        'department_updated' => 'Abteilung aktualisiert.',
+        'macro_applied' => 'Makro „:name" angewendet.',
+        'following' => 'Ticket wird verfolgt.',
+        'unfollowed' => 'Ticket wird nicht mehr verfolgt.',
+        'only_internal_notes_pinned' => 'Nur interne Notizen können angeheftet werden.',
+        'updated' => 'Ticket aktualisiert.',
+        'created' => 'Ticket erfolgreich erstellt.',
+        'closed' => 'Ticket geschlossen.',
+        'reopened' => 'Ticket wiedereröffnet.',
+        'customers_cannot_close' => 'Kunden können Tickets nicht schließen.',
+    ],
+
+    'guest' => [
+        'created' => 'Ticket erstellt. Speichern Sie diesen Link, um den Status Ihres Tickets zu überprüfen.',
+        'ticket_closed' => 'Dieses Ticket ist geschlossen.',
+    ],
+
+    'bulk' => [
+        'updated' => ':count Ticket(s) aktualisiert.',
+    ],
+
+    'rating' => [
+        'only_resolved_closed' => 'Sie können nur gelöste oder geschlossene Tickets bewerten.',
+        'already_rated' => 'Dieses Ticket wurde bereits bewertet.',
+        'thanks' => 'Vielen Dank für Ihr Feedback!',
+    ],
+
+    'canned_response' => [
+        'created' => 'Vordefinierte Antwort erstellt.',
+        'updated' => 'Vordefinierte Antwort aktualisiert.',
+        'deleted' => 'Vordefinierte Antwort gelöscht.',
+    ],
+
+    'department' => [
+        'created' => 'Abteilung erstellt.',
+        'updated' => 'Abteilung aktualisiert.',
+        'deleted' => 'Abteilung gelöscht.',
+    ],
+
+    'tag' => [
+        'created' => 'Tag erstellt.',
+        'updated' => 'Tag aktualisiert.',
+        'deleted' => 'Tag gelöscht.',
+    ],
+
+    'macro' => [
+        'created' => 'Makro erstellt.',
+        'updated' => 'Makro aktualisiert.',
+        'deleted' => 'Makro gelöscht.',
+    ],
+
+    'escalation_rule' => [
+        'created' => 'Regel erstellt.',
+        'updated' => 'Regel aktualisiert.',
+        'deleted' => 'Regel gelöscht.',
+    ],
+
+    'sla_policy' => [
+        'created' => 'SLA-Richtlinie erstellt.',
+        'updated' => 'SLA-Richtlinie aktualisiert.',
+        'deleted' => 'SLA-Richtlinie gelöscht.',
+    ],
+
+    'settings' => [
+        'updated' => 'Einstellungen aktualisiert.',
+    ],
+
+    'plugin' => [
+        'uploaded' => 'Plugin erfolgreich hochgeladen. Sie können es jetzt aktivieren.',
+        'upload_failed' => 'Plugin-Upload fehlgeschlagen: :error',
+        'activated' => 'Plugin erfolgreich aktiviert.',
+        'activate_failed' => 'Plugin-Aktivierung fehlgeschlagen: :error',
+        'deactivated' => 'Plugin erfolgreich deaktiviert.',
+        'deactivate_failed' => 'Plugin-Deaktivierung fehlgeschlagen: :error',
+        'composer_delete' => 'Composer-Plugins können nicht gelöscht werden. Entfernen Sie das Paket über Composer.',
+        'deleted' => 'Plugin erfolgreich gelöscht.',
+        'delete_failed' => 'Plugin-Löschung fehlgeschlagen: :error',
+    ],
+
+    'middleware' => [
+        'not_admin' => 'Sie sind nicht als Support-Administrator autorisiert.',
+        'not_agent' => 'Sie sind nicht als Support-Mitarbeiter autorisiert.',
+    ],
+
+    'inbound_email' => [
+        'disabled' => 'Eingehende E-Mails sind deaktiviert.',
+        'unknown_adapter' => 'Unbekannter Adapter.',
+        'invalid_signature' => 'Ungültige Signatur.',
+        'processing_failed' => 'Verarbeitung fehlgeschlagen.',
+    ],
+
+];

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -1,0 +1,70 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'subject' => '[:reference] Neues Ticket: :subject',
+        'line1' => 'Ein neues Support-Ticket wurde erstellt.',
+        'subject_line' => '**Betreff:** :subject',
+        'priority_line' => '**Priorität:** :priority',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Vielen Dank, dass Sie unser Support-System nutzen.',
+    ],
+
+    'ticket_assigned' => [
+        'subject' => '[:reference] Ticket Ihnen zugewiesen',
+        'line1' => 'Ihnen wurde ein Ticket zugewiesen.',
+        'subject_line' => '**Betreff:** :subject',
+        'priority_line' => '**Priorität:** :priority',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Bitte überprüfen und antworten Sie so bald wie möglich.',
+    ],
+
+    'ticket_reply' => [
+        'subject' => 'Re: [:reference] :subject',
+        'line1' => 'Eine neue Antwort wurde zu Ihrem Ticket hinzugefügt.',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Vielen Dank, dass Sie unser Support-System nutzen.',
+    ],
+
+    'ticket_resolved' => [
+        'subject' => '[:reference] Ticket gelöst',
+        'line1' => 'Ihr Support-Ticket wurde gelöst.',
+        'subject_line' => '**Betreff:** :subject',
+        'reopen_line' => 'Wenn Sie weitere Hilfe benötigen, können Sie dieses Ticket erneut öffnen.',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Vielen Dank, dass Sie unser Support-System nutzen.',
+    ],
+
+    'ticket_status_changed' => [
+        'subject' => '[:reference] Status aktualisiert: :status',
+        'line1' => 'Der Status Ihres Tickets wurde aktualisiert.',
+        'from_line' => '**Von:** :status',
+        'to_line' => '**Zu:** :status',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Vielen Dank, dass Sie unser Support-System nutzen.',
+    ],
+
+    'sla_breach' => [
+        'subject' => '[SLA-Verletzung] [:reference] :type-SLA verletzt',
+        'type_first_response' => 'Erste Antwort',
+        'type_resolution' => 'Lösung',
+        'line1' => 'Ein SLA wurde bei Ticket :reference verletzt.',
+        'type_line' => '**Typ:** :type-SLA',
+        'subject_line' => '**Betreff:** :subject',
+        'priority_line' => '**Priorität:** :priority',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Sofortige Aufmerksamkeit ist erforderlich.',
+    ],
+
+    'ticket_escalated' => [
+        'subject' => '[Eskaliert] [:reference] :subject',
+        'line1' => 'Ein Ticket wurde eskaliert.',
+        'subject_line' => '**Betreff:** :subject',
+        'priority_line' => '**Priorität:** :priority',
+        'reason_line' => '**Grund:** :reason',
+        'action' => 'Ticket ansehen',
+        'closing' => 'Sofortige Aufmerksamkeit ist erforderlich.',
+    ],
+
+];

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    'install' => [
+        'installing' => 'Installing Escalated...',
+        'publishing_config' => 'Publishing configuration',
+        'publishing_migrations' => 'Publishing migrations',
+        'publishing_views' => 'Publishing email views',
+        'installing_npm' => 'Installing npm package',
+        'npm_manual' => 'Could not install npm package automatically. Run manually:',
+        'success' => 'Escalated installed successfully!',
+        'next_steps' => 'Next steps:',
+        'step1' => '1. Implement the Ticketable interface on your User model:',
+        'step2' => '2. Define authorization gates in your AuthServiceProvider:',
+        'step3' => '3. Run migrations:',
+        'step4' => '4. Add Escalated pages to your Tailwind content config:',
+        'step5' => '5. Add the Inertia page resolver and plugin in your app.ts:',
+        'step6' => '6. Visit /support to see the customer portal',
+    ],
+
+];

--- a/resources/lang/en/emails.php
+++ b/resources/lang/en/emails.php
@@ -1,0 +1,82 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'heading' => 'New Support Ticket',
+        'intro' => 'A new support ticket has been created.',
+        'reference_label' => 'Reference',
+        'subject_label' => 'Subject',
+        'priority_label' => 'Priority',
+        'button' => 'View Ticket',
+        'thanks' => 'Thank you',
+    ],
+
+    'assigned' => [
+        'heading' => 'Ticket Assigned to You',
+        'intro' => 'A support ticket has been assigned to you.',
+        'reference_label' => 'Reference',
+        'subject_label' => 'Subject',
+        'priority_label' => 'Priority',
+        'status_label' => 'Status',
+        'button' => 'View Ticket',
+        'closing' => 'Please review and respond at your earliest convenience.',
+        'thanks' => 'Thank you',
+    ],
+
+    'reply' => [
+        'heading' => 'New Reply on :reference',
+        'intro' => 'A new reply has been added to your support ticket.',
+        'subject_label' => 'Subject',
+        'button' => 'View Ticket',
+        'thanks' => 'Thank you',
+    ],
+
+    'resolved' => [
+        'heading' => 'Ticket Resolved',
+        'intro' => 'Your support ticket has been resolved.',
+        'reference_label' => 'Reference',
+        'subject_label' => 'Subject',
+        'reopen_note' => 'If you need further assistance, you can reopen this ticket.',
+        'button' => 'View Ticket',
+        'thanks' => 'Thank you',
+    ],
+
+    'status_changed' => [
+        'heading' => 'Ticket Status Updated',
+        'intro' => 'The status of your support ticket has been updated.',
+        'reference_label' => 'Reference',
+        'subject_label' => 'Subject',
+        'previous_status_label' => 'Previous Status',
+        'new_status_label' => 'New Status',
+        'button' => 'View Ticket',
+        'thanks' => 'Thank you',
+    ],
+
+    'escalated' => [
+        'heading' => 'Ticket Escalated',
+        'intro' => 'A support ticket has been escalated.',
+        'reference_label' => 'Reference',
+        'subject_label' => 'Subject',
+        'priority_label' => 'Priority',
+        'reason_label' => 'Reason',
+        'attention_note' => 'Immediate attention is required.',
+        'button' => 'View Ticket',
+        'thanks' => 'Thank you',
+    ],
+
+    'sla_breach' => [
+        'heading' => 'SLA Breach Alert',
+        'intro' => 'An SLA has been breached on a support ticket.',
+        'reference_label' => 'Reference',
+        'subject_label' => 'Subject',
+        'priority_label' => 'Priority',
+        'breach_type_label' => 'Breach Type',
+        'first_response' => 'First Response',
+        'resolution' => 'Resolution',
+        'attention_note' => 'Immediate attention is required.',
+        'button' => 'View Ticket',
+        'thanks' => 'Thank you',
+    ],
+
+];

--- a/resources/lang/en/enums.php
+++ b/resources/lang/en/enums.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    'status' => [
+        'open' => 'Open',
+        'in_progress' => 'In Progress',
+        'waiting_on_customer' => 'Waiting on Customer',
+        'waiting_on_agent' => 'Waiting on Agent',
+        'escalated' => 'Escalated',
+        'resolved' => 'Resolved',
+        'closed' => 'Closed',
+        'reopened' => 'Reopened',
+    ],
+
+    'priority' => [
+        'low' => 'Low',
+        'medium' => 'Medium',
+        'high' => 'High',
+        'urgent' => 'Urgent',
+        'critical' => 'Critical',
+    ],
+
+    'activity_type' => [
+        'status_changed' => 'Status Changed',
+        'assigned' => 'Assigned',
+        'unassigned' => 'Unassigned',
+        'priority_changed' => 'Priority Changed',
+        'tag_added' => 'Tag Added',
+        'tag_removed' => 'Tag Removed',
+        'escalated' => 'Escalated',
+        'sla_breached' => 'SLA Breached',
+        'replied' => 'Replied',
+        'note_added' => 'Note Added',
+        'department_changed' => 'Department Changed',
+        'reopened' => 'Reopened',
+        'resolved' => 'Resolved',
+        'closed' => 'Closed',
+    ],
+
+];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -1,0 +1,103 @@
+<?php
+
+return [
+
+    'ticket' => [
+        'reply_sent' => 'Reply sent.',
+        'note_added' => 'Note added.',
+        'assigned' => 'Ticket assigned.',
+        'status_updated' => 'Status updated.',
+        'priority_updated' => 'Priority updated.',
+        'tags_updated' => 'Tags updated.',
+        'department_updated' => 'Department updated.',
+        'macro_applied' => 'Macro ":name" applied.',
+        'following' => 'Following ticket.',
+        'unfollowed' => 'Unfollowed ticket.',
+        'only_internal_notes_pinned' => 'Only internal notes can be pinned.',
+        'updated' => 'Ticket updated.',
+        'created' => 'Ticket created successfully.',
+        'closed' => 'Ticket closed.',
+        'reopened' => 'Ticket reopened.',
+        'customers_cannot_close' => 'Customers cannot close tickets.',
+    ],
+
+    'guest' => [
+        'created' => 'Ticket created. Save this link to check your ticket status.',
+        'ticket_closed' => 'This ticket is closed.',
+    ],
+
+    'bulk' => [
+        'updated' => ':count ticket(s) updated.',
+    ],
+
+    'rating' => [
+        'only_resolved_closed' => 'You can only rate resolved or closed tickets.',
+        'already_rated' => 'This ticket has already been rated.',
+        'thanks' => 'Thank you for your feedback!',
+    ],
+
+    'canned_response' => [
+        'created' => 'Canned response created.',
+        'updated' => 'Canned response updated.',
+        'deleted' => 'Canned response deleted.',
+    ],
+
+    'department' => [
+        'created' => 'Department created.',
+        'updated' => 'Department updated.',
+        'deleted' => 'Department deleted.',
+    ],
+
+    'tag' => [
+        'created' => 'Tag created.',
+        'updated' => 'Tag updated.',
+        'deleted' => 'Tag deleted.',
+    ],
+
+    'macro' => [
+        'created' => 'Macro created.',
+        'updated' => 'Macro updated.',
+        'deleted' => 'Macro deleted.',
+    ],
+
+    'escalation_rule' => [
+        'created' => 'Rule created.',
+        'updated' => 'Rule updated.',
+        'deleted' => 'Rule deleted.',
+    ],
+
+    'sla_policy' => [
+        'created' => 'SLA Policy created.',
+        'updated' => 'SLA Policy updated.',
+        'deleted' => 'SLA Policy deleted.',
+    ],
+
+    'settings' => [
+        'updated' => 'Settings updated.',
+    ],
+
+    'plugin' => [
+        'uploaded' => 'Plugin uploaded successfully. You can now activate it.',
+        'upload_failed' => 'Failed to upload plugin: :error',
+        'activated' => 'Plugin activated successfully.',
+        'activate_failed' => 'Failed to activate plugin: :error',
+        'deactivated' => 'Plugin deactivated successfully.',
+        'deactivate_failed' => 'Failed to deactivate plugin: :error',
+        'composer_delete' => 'Composer plugins cannot be deleted. Remove the package via Composer instead.',
+        'deleted' => 'Plugin deleted successfully.',
+        'delete_failed' => 'Failed to delete plugin: :error',
+    ],
+
+    'middleware' => [
+        'not_admin' => 'You are not authorized as a support administrator.',
+        'not_agent' => 'You are not authorized as a support agent.',
+    ],
+
+    'inbound_email' => [
+        'disabled' => 'Inbound email is disabled.',
+        'unknown_adapter' => 'Unknown adapter.',
+        'invalid_signature' => 'Invalid signature.',
+        'processing_failed' => 'Processing failed.',
+    ],
+
+];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -1,0 +1,70 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'subject' => '[:reference] New Ticket: :subject',
+        'line1' => 'A new support ticket has been created.',
+        'subject_line' => '**Subject:** :subject',
+        'priority_line' => '**Priority:** :priority',
+        'action' => 'View Ticket',
+        'closing' => 'Thank you for using our support system.',
+    ],
+
+    'ticket_assigned' => [
+        'subject' => '[:reference] Ticket Assigned to You',
+        'line1' => 'A ticket has been assigned to you.',
+        'subject_line' => '**Subject:** :subject',
+        'priority_line' => '**Priority:** :priority',
+        'action' => 'View Ticket',
+        'closing' => 'Please review and respond at your earliest convenience.',
+    ],
+
+    'ticket_reply' => [
+        'subject' => 'Re: [:reference] :subject',
+        'line1' => 'A new reply has been added to your ticket.',
+        'action' => 'View Ticket',
+        'closing' => 'Thank you for using our support system.',
+    ],
+
+    'ticket_resolved' => [
+        'subject' => '[:reference] Ticket Resolved',
+        'line1' => 'Your support ticket has been resolved.',
+        'subject_line' => '**Subject:** :subject',
+        'reopen_line' => 'If you need further assistance, you can reopen this ticket.',
+        'action' => 'View Ticket',
+        'closing' => 'Thank you for using our support system.',
+    ],
+
+    'ticket_status_changed' => [
+        'subject' => '[:reference] Status Updated: :status',
+        'line1' => 'The status of your ticket has been updated.',
+        'from_line' => '**From:** :status',
+        'to_line' => '**To:** :status',
+        'action' => 'View Ticket',
+        'closing' => 'Thank you for using our support system.',
+    ],
+
+    'sla_breach' => [
+        'subject' => '[SLA Breach] [:reference] :type SLA Breached',
+        'type_first_response' => 'First Response',
+        'type_resolution' => 'Resolution',
+        'line1' => 'An SLA has been breached on ticket :reference.',
+        'type_line' => '**Type:** :type SLA',
+        'subject_line' => '**Subject:** :subject',
+        'priority_line' => '**Priority:** :priority',
+        'action' => 'View Ticket',
+        'closing' => 'Immediate attention is required.',
+    ],
+
+    'ticket_escalated' => [
+        'subject' => '[Escalated] [:reference] :subject',
+        'line1' => 'A ticket has been escalated.',
+        'subject_line' => '**Subject:** :subject',
+        'priority_line' => '**Priority:** :priority',
+        'reason_line' => '**Reason:** :reason',
+        'action' => 'View Ticket',
+        'closing' => 'Immediate attention is required.',
+    ],
+
+];

--- a/resources/lang/es/commands.php
+++ b/resources/lang/es/commands.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    'install' => [
+        'installing' => 'Instalando Escalated...',
+        'publishing_config' => 'Publicando configuración',
+        'publishing_migrations' => 'Publicando migraciones',
+        'publishing_views' => 'Publicando vistas de correo',
+        'installing_npm' => 'Instalando paquete npm',
+        'npm_manual' => 'No se pudo instalar el paquete npm automáticamente. Ejecute manualmente:',
+        'success' => '¡Escalated instalado exitosamente!',
+        'next_steps' => 'Próximos pasos:',
+        'step1' => '1. Implemente la interfaz Ticketable en su modelo User:',
+        'step2' => '2. Defina las puertas de autorización en su AuthServiceProvider:',
+        'step3' => '3. Ejecute las migraciones:',
+        'step4' => '4. Añada las páginas de Escalated a la configuración de contenido de Tailwind:',
+        'step5' => '5. Añada el resolvedor de páginas Inertia y el plugin en su app.ts:',
+        'step6' => '6. Visite /support para ver el portal del cliente',
+    ],
+
+];

--- a/resources/lang/es/emails.php
+++ b/resources/lang/es/emails.php
@@ -1,0 +1,82 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'heading' => 'Nuevo ticket de soporte',
+        'intro' => 'Se ha creado un nuevo ticket de soporte.',
+        'reference_label' => 'Referencia',
+        'subject_label' => 'Asunto',
+        'priority_label' => 'Prioridad',
+        'button' => 'Ver ticket',
+        'thanks' => 'Gracias',
+    ],
+
+    'assigned' => [
+        'heading' => 'Ticket asignado a usted',
+        'intro' => 'Se le ha asignado un ticket de soporte.',
+        'reference_label' => 'Referencia',
+        'subject_label' => 'Asunto',
+        'priority_label' => 'Prioridad',
+        'status_label' => 'Estado',
+        'button' => 'Ver ticket',
+        'closing' => 'Por favor, revise y responda a la mayor brevedad posible.',
+        'thanks' => 'Gracias',
+    ],
+
+    'reply' => [
+        'heading' => 'Nueva respuesta en :reference',
+        'intro' => 'Se ha añadido una nueva respuesta a su ticket de soporte.',
+        'subject_label' => 'Asunto',
+        'button' => 'Ver ticket',
+        'thanks' => 'Gracias',
+    ],
+
+    'resolved' => [
+        'heading' => 'Ticket resuelto',
+        'intro' => 'Su ticket de soporte ha sido resuelto.',
+        'reference_label' => 'Referencia',
+        'subject_label' => 'Asunto',
+        'reopen_note' => 'Si necesita más ayuda, puede reabrir este ticket.',
+        'button' => 'Ver ticket',
+        'thanks' => 'Gracias',
+    ],
+
+    'status_changed' => [
+        'heading' => 'Estado del ticket actualizado',
+        'intro' => 'El estado de su ticket de soporte ha sido actualizado.',
+        'reference_label' => 'Referencia',
+        'subject_label' => 'Asunto',
+        'previous_status_label' => 'Estado anterior',
+        'new_status_label' => 'Nuevo estado',
+        'button' => 'Ver ticket',
+        'thanks' => 'Gracias',
+    ],
+
+    'escalated' => [
+        'heading' => 'Ticket escalado',
+        'intro' => 'Un ticket de soporte ha sido escalado.',
+        'reference_label' => 'Referencia',
+        'subject_label' => 'Asunto',
+        'priority_label' => 'Prioridad',
+        'reason_label' => 'Motivo',
+        'attention_note' => 'Se requiere atención inmediata.',
+        'button' => 'Ver ticket',
+        'thanks' => 'Gracias',
+    ],
+
+    'sla_breach' => [
+        'heading' => 'Alerta de incumplimiento SLA',
+        'intro' => 'Se ha incumplido un SLA en un ticket de soporte.',
+        'reference_label' => 'Referencia',
+        'subject_label' => 'Asunto',
+        'priority_label' => 'Prioridad',
+        'breach_type_label' => 'Tipo de incumplimiento',
+        'first_response' => 'Primera respuesta',
+        'resolution' => 'Resolución',
+        'attention_note' => 'Se requiere atención inmediata.',
+        'button' => 'Ver ticket',
+        'thanks' => 'Gracias',
+    ],
+
+];

--- a/resources/lang/es/enums.php
+++ b/resources/lang/es/enums.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    'status' => [
+        'open' => 'Abierto',
+        'in_progress' => 'En progreso',
+        'waiting_on_customer' => 'Esperando al cliente',
+        'waiting_on_agent' => 'Esperando al agente',
+        'escalated' => 'Escalado',
+        'resolved' => 'Resuelto',
+        'closed' => 'Cerrado',
+        'reopened' => 'Reabierto',
+    ],
+
+    'priority' => [
+        'low' => 'Bajo',
+        'medium' => 'Medio',
+        'high' => 'Alto',
+        'urgent' => 'Urgente',
+        'critical' => 'Crítico',
+    ],
+
+    'activity_type' => [
+        'status_changed' => 'Estado cambiado',
+        'assigned' => 'Asignado',
+        'unassigned' => 'Desasignado',
+        'priority_changed' => 'Prioridad cambiada',
+        'tag_added' => 'Etiqueta añadida',
+        'tag_removed' => 'Etiqueta eliminada',
+        'escalated' => 'Escalado',
+        'sla_breached' => 'SLA incumplido',
+        'replied' => 'Respondido',
+        'note_added' => 'Nota añadida',
+        'department_changed' => 'Departamento cambiado',
+        'reopened' => 'Reabierto',
+        'resolved' => 'Resuelto',
+        'closed' => 'Cerrado',
+    ],
+
+];

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -1,0 +1,103 @@
+<?php
+
+return [
+
+    'ticket' => [
+        'reply_sent' => 'Respuesta enviada.',
+        'note_added' => 'Nota añadida.',
+        'assigned' => 'Ticket asignado.',
+        'status_updated' => 'Estado actualizado.',
+        'priority_updated' => 'Prioridad actualizada.',
+        'tags_updated' => 'Etiquetas actualizadas.',
+        'department_updated' => 'Departamento actualizado.',
+        'macro_applied' => 'Macro ":name" aplicada.',
+        'following' => 'Siguiendo ticket.',
+        'unfollowed' => 'Dejó de seguir el ticket.',
+        'only_internal_notes_pinned' => 'Solo se pueden fijar notas internas.',
+        'updated' => 'Ticket actualizado.',
+        'created' => 'Ticket creado exitosamente.',
+        'closed' => 'Ticket cerrado.',
+        'reopened' => 'Ticket reabierto.',
+        'customers_cannot_close' => 'Los clientes no pueden cerrar tickets.',
+    ],
+
+    'guest' => [
+        'created' => 'Ticket creado. Guarde este enlace para consultar el estado de su ticket.',
+        'ticket_closed' => 'Este ticket está cerrado.',
+    ],
+
+    'bulk' => [
+        'updated' => ':count ticket(s) actualizado(s).',
+    ],
+
+    'rating' => [
+        'only_resolved_closed' => 'Solo puede calificar tickets resueltos o cerrados.',
+        'already_rated' => 'Este ticket ya ha sido calificado.',
+        'thanks' => '¡Gracias por sus comentarios!',
+    ],
+
+    'canned_response' => [
+        'created' => 'Respuesta predefinida creada.',
+        'updated' => 'Respuesta predefinida actualizada.',
+        'deleted' => 'Respuesta predefinida eliminada.',
+    ],
+
+    'department' => [
+        'created' => 'Departamento creado.',
+        'updated' => 'Departamento actualizado.',
+        'deleted' => 'Departamento eliminado.',
+    ],
+
+    'tag' => [
+        'created' => 'Etiqueta creada.',
+        'updated' => 'Etiqueta actualizada.',
+        'deleted' => 'Etiqueta eliminada.',
+    ],
+
+    'macro' => [
+        'created' => 'Macro creada.',
+        'updated' => 'Macro actualizada.',
+        'deleted' => 'Macro eliminada.',
+    ],
+
+    'escalation_rule' => [
+        'created' => 'Regla creada.',
+        'updated' => 'Regla actualizada.',
+        'deleted' => 'Regla eliminada.',
+    ],
+
+    'sla_policy' => [
+        'created' => 'Política SLA creada.',
+        'updated' => 'Política SLA actualizada.',
+        'deleted' => 'Política SLA eliminada.',
+    ],
+
+    'settings' => [
+        'updated' => 'Configuración actualizada.',
+    ],
+
+    'plugin' => [
+        'uploaded' => 'Plugin cargado exitosamente. Ahora puede activarlo.',
+        'upload_failed' => 'Error al cargar el plugin: :error',
+        'activated' => 'Plugin activado exitosamente.',
+        'activate_failed' => 'Error al activar el plugin: :error',
+        'deactivated' => 'Plugin desactivado exitosamente.',
+        'deactivate_failed' => 'Error al desactivar el plugin: :error',
+        'composer_delete' => 'Los plugins de Composer no se pueden eliminar. Elimine el paquete a través de Composer.',
+        'deleted' => 'Plugin eliminado exitosamente.',
+        'delete_failed' => 'Error al eliminar el plugin: :error',
+    ],
+
+    'middleware' => [
+        'not_admin' => 'No está autorizado como administrador de soporte.',
+        'not_agent' => 'No está autorizado como agente de soporte.',
+    ],
+
+    'inbound_email' => [
+        'disabled' => 'El correo entrante está deshabilitado.',
+        'unknown_adapter' => 'Adaptador desconocido.',
+        'invalid_signature' => 'Firma no válida.',
+        'processing_failed' => 'Error en el procesamiento.',
+    ],
+
+];

--- a/resources/lang/es/notifications.php
+++ b/resources/lang/es/notifications.php
@@ -1,0 +1,70 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'subject' => '[:reference] Nuevo ticket: :subject',
+        'line1' => 'Se ha creado un nuevo ticket de soporte.',
+        'subject_line' => '**Asunto:** :subject',
+        'priority_line' => '**Prioridad:** :priority',
+        'action' => 'Ver ticket',
+        'closing' => 'Gracias por utilizar nuestro sistema de soporte.',
+    ],
+
+    'ticket_assigned' => [
+        'subject' => '[:reference] Ticket asignado a usted',
+        'line1' => 'Se le ha asignado un ticket.',
+        'subject_line' => '**Asunto:** :subject',
+        'priority_line' => '**Prioridad:** :priority',
+        'action' => 'Ver ticket',
+        'closing' => 'Por favor, revise y responda a la mayor brevedad posible.',
+    ],
+
+    'ticket_reply' => [
+        'subject' => 'Re: [:reference] :subject',
+        'line1' => 'Se ha añadido una nueva respuesta a su ticket.',
+        'action' => 'Ver ticket',
+        'closing' => 'Gracias por utilizar nuestro sistema de soporte.',
+    ],
+
+    'ticket_resolved' => [
+        'subject' => '[:reference] Ticket resuelto',
+        'line1' => 'Su ticket de soporte ha sido resuelto.',
+        'subject_line' => '**Asunto:** :subject',
+        'reopen_line' => 'Si necesita más ayuda, puede reabrir este ticket.',
+        'action' => 'Ver ticket',
+        'closing' => 'Gracias por utilizar nuestro sistema de soporte.',
+    ],
+
+    'ticket_status_changed' => [
+        'subject' => '[:reference] Estado actualizado: :status',
+        'line1' => 'El estado de su ticket ha sido actualizado.',
+        'from_line' => '**De:** :status',
+        'to_line' => '**A:** :status',
+        'action' => 'Ver ticket',
+        'closing' => 'Gracias por utilizar nuestro sistema de soporte.',
+    ],
+
+    'sla_breach' => [
+        'subject' => '[Incumplimiento SLA] [:reference] SLA de :type incumplido',
+        'type_first_response' => 'Primera respuesta',
+        'type_resolution' => 'Resolución',
+        'line1' => 'Se ha incumplido un SLA en el ticket :reference.',
+        'type_line' => '**Tipo:** SLA de :type',
+        'subject_line' => '**Asunto:** :subject',
+        'priority_line' => '**Prioridad:** :priority',
+        'action' => 'Ver ticket',
+        'closing' => 'Se requiere atención inmediata.',
+    ],
+
+    'ticket_escalated' => [
+        'subject' => '[Escalado] [:reference] :subject',
+        'line1' => 'Un ticket ha sido escalado.',
+        'subject_line' => '**Asunto:** :subject',
+        'priority_line' => '**Prioridad:** :priority',
+        'reason_line' => '**Motivo:** :reason',
+        'action' => 'Ver ticket',
+        'closing' => 'Se requiere atención inmediata.',
+    ],
+
+];

--- a/resources/lang/fr/commands.php
+++ b/resources/lang/fr/commands.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    'install' => [
+        'installing' => 'Installation d\'Escalated...',
+        'publishing_config' => 'Publication de la configuration',
+        'publishing_migrations' => 'Publication des migrations',
+        'publishing_views' => 'Publication des vues e-mail',
+        'installing_npm' => 'Installation du paquet npm',
+        'npm_manual' => 'Impossible d\'installer le paquet npm automatiquement. Exécutez manuellement :',
+        'success' => 'Escalated installé avec succès !',
+        'next_steps' => 'Prochaines étapes :',
+        'step1' => '1. Implémentez l\'interface Ticketable sur votre modèle User :',
+        'step2' => '2. Définissez les portes d\'autorisation dans votre AuthServiceProvider :',
+        'step3' => '3. Exécutez les migrations :',
+        'step4' => '4. Ajoutez les pages Escalated à la configuration de contenu Tailwind :',
+        'step5' => '5. Ajoutez le résolveur de pages Inertia et le plugin dans votre app.ts :',
+        'step6' => '6. Visitez /support pour voir le portail client',
+    ],
+
+];

--- a/resources/lang/fr/emails.php
+++ b/resources/lang/fr/emails.php
@@ -1,0 +1,82 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'heading' => 'Nouveau ticket de support',
+        'intro' => 'Un nouveau ticket de support a été créé.',
+        'reference_label' => 'Référence',
+        'subject_label' => 'Objet',
+        'priority_label' => 'Priorité',
+        'button' => 'Voir le ticket',
+        'thanks' => 'Merci',
+    ],
+
+    'assigned' => [
+        'heading' => 'Ticket qui vous est assigné',
+        'intro' => 'Un ticket de support vous a été assigné.',
+        'reference_label' => 'Référence',
+        'subject_label' => 'Objet',
+        'priority_label' => 'Priorité',
+        'status_label' => 'Statut',
+        'button' => 'Voir le ticket',
+        'closing' => 'Veuillez examiner et répondre dans les meilleurs délais.',
+        'thanks' => 'Merci',
+    ],
+
+    'reply' => [
+        'heading' => 'Nouvelle réponse sur :reference',
+        'intro' => 'Une nouvelle réponse a été ajoutée à votre ticket de support.',
+        'subject_label' => 'Objet',
+        'button' => 'Voir le ticket',
+        'thanks' => 'Merci',
+    ],
+
+    'resolved' => [
+        'heading' => 'Ticket résolu',
+        'intro' => 'Votre ticket de support a été résolu.',
+        'reference_label' => 'Référence',
+        'subject_label' => 'Objet',
+        'reopen_note' => 'Si vous avez besoin d\'aide supplémentaire, vous pouvez rouvrir ce ticket.',
+        'button' => 'Voir le ticket',
+        'thanks' => 'Merci',
+    ],
+
+    'status_changed' => [
+        'heading' => 'Statut du ticket mis à jour',
+        'intro' => 'Le statut de votre ticket de support a été mis à jour.',
+        'reference_label' => 'Référence',
+        'subject_label' => 'Objet',
+        'previous_status_label' => 'Statut précédent',
+        'new_status_label' => 'Nouveau statut',
+        'button' => 'Voir le ticket',
+        'thanks' => 'Merci',
+    ],
+
+    'escalated' => [
+        'heading' => 'Ticket escaladé',
+        'intro' => 'Un ticket de support a été escaladé.',
+        'reference_label' => 'Référence',
+        'subject_label' => 'Objet',
+        'priority_label' => 'Priorité',
+        'reason_label' => 'Raison',
+        'attention_note' => 'Une attention immédiate est requise.',
+        'button' => 'Voir le ticket',
+        'thanks' => 'Merci',
+    ],
+
+    'sla_breach' => [
+        'heading' => 'Alerte de violation SLA',
+        'intro' => 'Un SLA a été violé sur un ticket de support.',
+        'reference_label' => 'Référence',
+        'subject_label' => 'Objet',
+        'priority_label' => 'Priorité',
+        'breach_type_label' => 'Type de violation',
+        'first_response' => 'Première réponse',
+        'resolution' => 'Résolution',
+        'attention_note' => 'Une attention immédiate est requise.',
+        'button' => 'Voir le ticket',
+        'thanks' => 'Merci',
+    ],
+
+];

--- a/resources/lang/fr/enums.php
+++ b/resources/lang/fr/enums.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    'status' => [
+        'open' => 'Ouvert',
+        'in_progress' => 'En cours',
+        'waiting_on_customer' => 'En attente du client',
+        'waiting_on_agent' => "En attente de l'agent",
+        'escalated' => 'Escaladé',
+        'resolved' => 'Résolu',
+        'closed' => 'Fermé',
+        'reopened' => 'Réouvert',
+    ],
+
+    'priority' => [
+        'low' => 'Bas',
+        'medium' => 'Moyen',
+        'high' => 'Élevé',
+        'urgent' => 'Urgent',
+        'critical' => 'Critique',
+    ],
+
+    'activity_type' => [
+        'status_changed' => 'Statut modifié',
+        'assigned' => 'Assigné',
+        'unassigned' => 'Désassigné',
+        'priority_changed' => 'Priorité modifiée',
+        'tag_added' => 'Étiquette ajoutée',
+        'tag_removed' => 'Étiquette supprimée',
+        'escalated' => 'Escaladé',
+        'sla_breached' => 'SLA non respecté',
+        'replied' => 'Répondu',
+        'note_added' => 'Note ajoutée',
+        'department_changed' => 'Département modifié',
+        'reopened' => 'Réouvert',
+        'resolved' => 'Résolu',
+        'closed' => 'Fermé',
+    ],
+
+];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -1,0 +1,103 @@
+<?php
+
+return [
+
+    'ticket' => [
+        'reply_sent' => 'Réponse envoyée.',
+        'note_added' => 'Note ajoutée.',
+        'assigned' => 'Ticket assigné.',
+        'status_updated' => 'Statut mis à jour.',
+        'priority_updated' => 'Priorité mise à jour.',
+        'tags_updated' => 'Étiquettes mises à jour.',
+        'department_updated' => 'Département mis à jour.',
+        'macro_applied' => 'Macro « :name » appliquée.',
+        'following' => 'Vous suivez le ticket.',
+        'unfollowed' => 'Vous ne suivez plus le ticket.',
+        'only_internal_notes_pinned' => 'Seules les notes internes peuvent être épinglées.',
+        'updated' => 'Ticket mis à jour.',
+        'created' => 'Ticket créé avec succès.',
+        'closed' => 'Ticket fermé.',
+        'reopened' => 'Ticket réouvert.',
+        'customers_cannot_close' => 'Les clients ne peuvent pas fermer les tickets.',
+    ],
+
+    'guest' => [
+        'created' => 'Ticket créé. Enregistrez ce lien pour vérifier le statut de votre ticket.',
+        'ticket_closed' => 'Ce ticket est fermé.',
+    ],
+
+    'bulk' => [
+        'updated' => ':count ticket(s) mis à jour.',
+    ],
+
+    'rating' => [
+        'only_resolved_closed' => 'Vous ne pouvez évaluer que les tickets résolus ou fermés.',
+        'already_rated' => 'Ce ticket a déjà été évalué.',
+        'thanks' => 'Merci pour vos commentaires !',
+    ],
+
+    'canned_response' => [
+        'created' => 'Réponse prédéfinie créée.',
+        'updated' => 'Réponse prédéfinie mise à jour.',
+        'deleted' => 'Réponse prédéfinie supprimée.',
+    ],
+
+    'department' => [
+        'created' => 'Département créé.',
+        'updated' => 'Département mis à jour.',
+        'deleted' => 'Département supprimé.',
+    ],
+
+    'tag' => [
+        'created' => 'Étiquette créée.',
+        'updated' => 'Étiquette mise à jour.',
+        'deleted' => 'Étiquette supprimée.',
+    ],
+
+    'macro' => [
+        'created' => 'Macro créée.',
+        'updated' => 'Macro mise à jour.',
+        'deleted' => 'Macro supprimée.',
+    ],
+
+    'escalation_rule' => [
+        'created' => 'Règle créée.',
+        'updated' => 'Règle mise à jour.',
+        'deleted' => 'Règle supprimée.',
+    ],
+
+    'sla_policy' => [
+        'created' => 'Politique SLA créée.',
+        'updated' => 'Politique SLA mise à jour.',
+        'deleted' => 'Politique SLA supprimée.',
+    ],
+
+    'settings' => [
+        'updated' => 'Paramètres mis à jour.',
+    ],
+
+    'plugin' => [
+        'uploaded' => 'Plugin téléchargé avec succès. Vous pouvez maintenant l\'activer.',
+        'upload_failed' => 'Échec du téléchargement du plugin : :error',
+        'activated' => 'Plugin activé avec succès.',
+        'activate_failed' => 'Échec de l\'activation du plugin : :error',
+        'deactivated' => 'Plugin désactivé avec succès.',
+        'deactivate_failed' => 'Échec de la désactivation du plugin : :error',
+        'composer_delete' => 'Les plugins Composer ne peuvent pas être supprimés. Supprimez le paquet via Composer.',
+        'deleted' => 'Plugin supprimé avec succès.',
+        'delete_failed' => 'Échec de la suppression du plugin : :error',
+    ],
+
+    'middleware' => [
+        'not_admin' => 'Vous n\'êtes pas autorisé en tant qu\'administrateur de support.',
+        'not_agent' => 'Vous n\'êtes pas autorisé en tant qu\'agent de support.',
+    ],
+
+    'inbound_email' => [
+        'disabled' => 'Le courrier entrant est désactivé.',
+        'unknown_adapter' => 'Adaptateur inconnu.',
+        'invalid_signature' => 'Signature non valide.',
+        'processing_failed' => 'Échec du traitement.',
+    ],
+
+];

--- a/resources/lang/fr/notifications.php
+++ b/resources/lang/fr/notifications.php
@@ -1,0 +1,70 @@
+<?php
+
+return [
+
+    'new_ticket' => [
+        'subject' => '[:reference] Nouveau ticket : :subject',
+        'line1' => 'Un nouveau ticket de support a été créé.',
+        'subject_line' => '**Objet :** :subject',
+        'priority_line' => '**Priorité :** :priority',
+        'action' => 'Voir le ticket',
+        'closing' => 'Merci d\'utiliser notre système de support.',
+    ],
+
+    'ticket_assigned' => [
+        'subject' => '[:reference] Ticket qui vous est assigné',
+        'line1' => 'Un ticket vous a été assigné.',
+        'subject_line' => '**Objet :** :subject',
+        'priority_line' => '**Priorité :** :priority',
+        'action' => 'Voir le ticket',
+        'closing' => 'Veuillez examiner et répondre dans les meilleurs délais.',
+    ],
+
+    'ticket_reply' => [
+        'subject' => 'Re : [:reference] :subject',
+        'line1' => 'Une nouvelle réponse a été ajoutée à votre ticket.',
+        'action' => 'Voir le ticket',
+        'closing' => 'Merci d\'utiliser notre système de support.',
+    ],
+
+    'ticket_resolved' => [
+        'subject' => '[:reference] Ticket résolu',
+        'line1' => 'Votre ticket de support a été résolu.',
+        'subject_line' => '**Objet :** :subject',
+        'reopen_line' => 'Si vous avez besoin d\'aide supplémentaire, vous pouvez rouvrir ce ticket.',
+        'action' => 'Voir le ticket',
+        'closing' => 'Merci d\'utiliser notre système de support.',
+    ],
+
+    'ticket_status_changed' => [
+        'subject' => '[:reference] Statut mis à jour : :status',
+        'line1' => 'Le statut de votre ticket a été mis à jour.',
+        'from_line' => '**De :** :status',
+        'to_line' => '**À :** :status',
+        'action' => 'Voir le ticket',
+        'closing' => 'Merci d\'utiliser notre système de support.',
+    ],
+
+    'sla_breach' => [
+        'subject' => '[Violation SLA] [:reference] SLA de :type violé',
+        'type_first_response' => 'Première réponse',
+        'type_resolution' => 'Résolution',
+        'line1' => 'Un SLA a été violé sur le ticket :reference.',
+        'type_line' => '**Type :** SLA de :type',
+        'subject_line' => '**Objet :** :subject',
+        'priority_line' => '**Priorité :** :priority',
+        'action' => 'Voir le ticket',
+        'closing' => 'Une attention immédiate est requise.',
+    ],
+
+    'ticket_escalated' => [
+        'subject' => '[Escaladé] [:reference] :subject',
+        'line1' => 'Un ticket a été escaladé.',
+        'subject_line' => '**Objet :** :subject',
+        'priority_line' => '**Priorité :** :priority',
+        'reason_line' => '**Raison :** :reason',
+        'action' => 'Voir le ticket',
+        'closing' => 'Une attention immédiate est requise.',
+    ],
+
+];

--- a/resources/views/emails/assigned.blade.php
+++ b/resources/views/emails/assigned.blade.php
@@ -1,19 +1,19 @@
 @component('mail::message')
-# Ticket Assigned to You
+# {{ __('escalated::emails.assigned.heading') }}
 
-A support ticket has been assigned to you.
+{{ __('escalated::emails.assigned.intro') }}
 
-**Reference:** {{ ->reference }}
-**Subject:** {{ ->subject }}
-**Priority:** {{ ->priority->label() }}
-**Status:** {{ ->status->label() }}
+**{{ __('escalated::emails.assigned.reference_label') }}:** {{ $ticket->reference }}
+**{{ __('escalated::emails.assigned.subject_label') }}:** {{ $ticket->subject }}
+**{{ __('escalated::emails.assigned.priority_label') }}:** {{ $ticket->priority->label() }}
+**{{ __('escalated::emails.assigned.status_label') }}:** {{ $ticket->status->label() }}
 
-@component('mail::button', ['url' => ])
-View Ticket
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.assigned.button') }}
 @endcomponent
 
-Please review and respond at your earliest convenience.
+{{ __('escalated::emails.assigned.closing') }}
 
-Thank you,<br>
+{{ __('escalated::emails.assigned.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/escalated.blade.php
+++ b/resources/views/emails/escalated.blade.php
@@ -1,21 +1,21 @@
 @component('mail::message')
-# Ticket Escalated
+# {{ __('escalated::emails.escalated.heading') }}
 
-A support ticket has been escalated.
+{{ __('escalated::emails.escalated.intro') }}
 
-**Reference:** {{ ->reference }}
-**Subject:** {{ ->subject }}
-**Priority:** {{ ->priority->label() }}
-@if()
-**Reason:** {{  }}
+**{{ __('escalated::emails.escalated.reference_label') }}:** {{ $ticket->reference }}
+**{{ __('escalated::emails.escalated.subject_label') }}:** {{ $ticket->subject }}
+**{{ __('escalated::emails.escalated.priority_label') }}:** {{ $ticket->priority->label() }}
+@if($reason)
+**{{ __('escalated::emails.escalated.reason_label') }}:** {{ $reason }}
 @endif
 
-Immediate attention is required.
+{{ __('escalated::emails.escalated.attention_note') }}
 
-@component('mail::button', ['url' => ])
-View Ticket
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.escalated.button') }}
 @endcomponent
 
-Thank you,<br>
+{{ __('escalated::emails.escalated.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/new-ticket.blade.php
+++ b/resources/views/emails/new-ticket.blade.php
@@ -1,18 +1,18 @@
 @component('mail::message')
-# New Support Ticket
+# {{ __('escalated::emails.new_ticket.heading') }}
 
-A new support ticket has been created.
+{{ __('escalated::emails.new_ticket.intro') }}
 
-**Reference:** {{ ->reference }}
-**Subject:** {{ ->subject }}
-**Priority:** {{ ->priority->label() }}
+**{{ __('escalated::emails.new_ticket.reference_label') }}:** {{ $ticket->reference }}
+**{{ __('escalated::emails.new_ticket.subject_label') }}:** {{ $ticket->subject }}
+**{{ __('escalated::emails.new_ticket.priority_label') }}:** {{ $ticket->priority->label() }}
 
-{{ ->description }}
+{{ $ticket->description }}
 
-@component('mail::button', ['url' => ])
-View Ticket
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.new_ticket.button') }}
 @endcomponent
 
-Thank you,<br>
+{{ __('escalated::emails.new_ticket.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/reply.blade.php
+++ b/resources/views/emails/reply.blade.php
@@ -1,20 +1,20 @@
 @component('mail::message')
-# New Reply on {{ ->reference }}
+# {{ __('escalated::emails.reply.heading', ['reference' => $ticket->reference]) }}
 
-A new reply has been added to your support ticket.
+{{ __('escalated::emails.reply.intro') }}
 
-**Subject:** {{ ->subject }}
-
----
-
-{{ ->body }}
+**{{ __('escalated::emails.reply.subject_label') }}:** {{ $ticket->subject }}
 
 ---
 
-@component('mail::button', ['url' => ])
-View Ticket
+{{ $reply->body }}
+
+---
+
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.reply.button') }}
 @endcomponent
 
-Thank you,<br>
+{{ __('escalated::emails.reply.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/resolved.blade.php
+++ b/resources/views/emails/resolved.blade.php
@@ -1,17 +1,17 @@
 @component('mail::message')
-# Ticket Resolved
+# {{ __('escalated::emails.resolved.heading') }}
 
-Your support ticket has been resolved.
+{{ __('escalated::emails.resolved.intro') }}
 
-**Reference:** {{ ->reference }}
-**Subject:** {{ ->subject }}
+**{{ __('escalated::emails.resolved.reference_label') }}:** {{ $ticket->reference }}
+**{{ __('escalated::emails.resolved.subject_label') }}:** {{ $ticket->subject }}
 
-If you need further assistance, you can reopen this ticket.
+{{ __('escalated::emails.resolved.reopen_note') }}
 
-@component('mail::button', ['url' => ])
-View Ticket
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.resolved.button') }}
 @endcomponent
 
-Thank you,<br>
+{{ __('escalated::emails.resolved.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/sla-breach.blade.php
+++ b/resources/views/emails/sla-breach.blade.php
@@ -1,19 +1,19 @@
 @component('mail::message')
-# SLA Breach Alert
+# {{ __('escalated::emails.sla_breach.heading') }}
 
-An SLA has been breached on a support ticket.
+{{ __('escalated::emails.sla_breach.intro') }}
 
-**Reference:** {{ ->reference }}
-**Subject:** {{ ->subject }}
-**Priority:** {{ ->priority->label() }}
-**Breach Type:** {{  === 'first_response' ? 'First Response' : 'Resolution' }}
+**{{ __('escalated::emails.sla_breach.reference_label') }}:** {{ $ticket->reference }}
+**{{ __('escalated::emails.sla_breach.subject_label') }}:** {{ $ticket->subject }}
+**{{ __('escalated::emails.sla_breach.priority_label') }}:** {{ $ticket->priority->label() }}
+**{{ __('escalated::emails.sla_breach.breach_type_label') }}:** {{ $breachType === 'first_response' ? __('escalated::emails.sla_breach.first_response') : __('escalated::emails.sla_breach.resolution') }}
 
-Immediate attention is required.
+{{ __('escalated::emails.sla_breach.attention_note') }}
 
-@component('mail::button', ['url' => ])
-View Ticket
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.sla_breach.button') }}
 @endcomponent
 
-Thank you,<br>
+{{ __('escalated::emails.sla_breach.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/status-changed.blade.php
+++ b/resources/views/emails/status-changed.blade.php
@@ -1,17 +1,17 @@
 @component('mail::message')
-# Ticket Status Updated
+# {{ __('escalated::emails.status_changed.heading') }}
 
-The status of your support ticket has been updated.
+{{ __('escalated::emails.status_changed.intro') }}
 
-**Reference:** {{ ->reference }}
-**Subject:** {{ ->subject }}
-**Previous Status:** {{ ->label() }}
-**New Status:** {{ ->label() }}
+**{{ __('escalated::emails.status_changed.reference_label') }}:** {{ $ticket->reference }}
+**{{ __('escalated::emails.status_changed.subject_label') }}:** {{ $ticket->subject }}
+**{{ __('escalated::emails.status_changed.previous_status_label') }}:** {{ $oldStatus->label() }}
+**{{ __('escalated::emails.status_changed.new_status_label') }}:** {{ $newStatus->label() }}
 
-@component('mail::button', ['url' => ])
-View Ticket
+@component('mail::button', ['url' => $url])
+{{ __('escalated::emails.status_changed.button') }}
 @endcomponent
 
-Thank you,<br>
+{{ __('escalated::emails.status_changed.thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -16,7 +16,7 @@ class InstallCommand extends Command
 
     public function handle(): int
     {
-        $this->info('Installing Escalated...');
+        $this->info(__('escalated::commands.install.installing'));
         $this->newLine();
 
         $force = $this->option('force');
@@ -45,7 +45,7 @@ class InstallCommand extends Command
 
     protected function publishConfig(bool $force): void
     {
-        $this->components->task('Publishing configuration', function () use ($force) {
+        $this->components->task(__('escalated::commands.install.publishing_config'), function () use ($force) {
             $this->callSilently('vendor:publish', [
                 '--tag' => 'escalated-config',
                 '--force' => $force,
@@ -55,7 +55,7 @@ class InstallCommand extends Command
 
     protected function publishMigrations(bool $force): void
     {
-        $this->components->task('Publishing migrations', function () use ($force) {
+        $this->components->task(__('escalated::commands.install.publishing_migrations'), function () use ($force) {
             $this->callSilently('vendor:publish', [
                 '--tag' => 'escalated-migrations',
                 '--force' => $force,
@@ -65,7 +65,7 @@ class InstallCommand extends Command
 
     protected function publishEmailViews(bool $force): void
     {
-        $this->components->task('Publishing email views', function () use ($force) {
+        $this->components->task(__('escalated::commands.install.publishing_views'), function () use ($force) {
             $this->callSilently('vendor:publish', [
                 '--tag' => 'escalated-views',
                 '--force' => $force,
@@ -75,11 +75,11 @@ class InstallCommand extends Command
 
     protected function installNpmPackage(): void
     {
-        $this->components->task('Installing npm package', function () {
+        $this->components->task(__('escalated::commands.install.installing_npm'), function () {
             $result = Process::run('npm install @escalated-dev/escalated');
 
             if (! $result->successful()) {
-                $this->components->warn('Could not install npm package automatically. Run manually:');
+                $this->components->warn(__('escalated::commands.install.npm_manual'));
                 $this->line('  npm install @escalated-dev/escalated');
 
                 return false;
@@ -89,12 +89,12 @@ class InstallCommand extends Command
 
     protected function outputSetupInstructions(): void
     {
-        $this->components->info('Escalated installed successfully!');
+        $this->components->info(__('escalated::commands.install.success'));
         $this->newLine();
 
-        $this->line('  Next steps:');
+        $this->line('  '.__('escalated::commands.install.next_steps'));
         $this->newLine();
-        $this->line('  1. Implement the Ticketable interface on your User model:');
+        $this->line('  '.__('escalated::commands.install.step1'));
         $this->newLine();
         $this->line('     use Escalated\Laravel\Contracts\HasTickets;');
         $this->line('     use Escalated\Laravel\Contracts\Ticketable;');
@@ -104,16 +104,16 @@ class InstallCommand extends Command
         $this->line('         use HasTickets;');
         $this->line('     }');
         $this->newLine();
-        $this->line('  2. Define authorization gates in your AuthServiceProvider:');
+        $this->line('  '.__('escalated::commands.install.step2'));
         $this->newLine();
         $this->line('     Gate::define(\'escalated-admin\', fn ($user) => $user->is_admin);');
         $this->line('     Gate::define(\'escalated-agent\', fn ($user) => $user->is_agent);');
         $this->newLine();
-        $this->line('  3. Run migrations:');
+        $this->line('  '.__('escalated::commands.install.step3'));
         $this->newLine();
         $this->line('     php artisan migrate');
         $this->newLine();
-        $this->line('  4. Add Escalated pages to your Tailwind content config:');
+        $this->line('  '.__('escalated::commands.install.step4'));
         $this->newLine();
         $this->line('     // tailwind.config.js');
         $this->line('     content: [');
@@ -121,7 +121,7 @@ class InstallCommand extends Command
         $this->line('         \'./node_modules/@escalated-dev/escalated/src/**/*.vue\',');
         $this->line('     ]');
         $this->newLine();
-        $this->line('  5. Add the Inertia page resolver and plugin in your app.ts:');
+        $this->line('  '.__('escalated::commands.install.step5'));
         $this->newLine();
         $this->line('     import { EscalatedPlugin } from \'@escalated-dev/escalated\';');
         $this->newLine();
@@ -143,7 +143,7 @@ class InstallCommand extends Command
         $this->line('     // In setup:');
         $this->line('     app.use(EscalatedPlugin, { layout: YourAppLayout })');
         $this->newLine();
-        $this->line('  6. Visit /support to see the customer portal');
+        $this->line('  '.__('escalated::commands.install.step6'));
         $this->newLine();
     }
 }

--- a/src/Enums/ActivityType.php
+++ b/src/Enums/ActivityType.php
@@ -21,6 +21,6 @@ enum ActivityType: string
 
     public function label(): string
     {
-        return str_replace('_', ' ', ucfirst($this->value));
+        return __('escalated::enums.activity_type.'.$this->value);
     }
 }

--- a/src/Enums/TicketPriority.php
+++ b/src/Enums/TicketPriority.php
@@ -12,13 +12,7 @@ enum TicketPriority: string
 
     public function label(): string
     {
-        return match ($this) {
-            self::Low => 'Low',
-            self::Medium => 'Medium',
-            self::High => 'High',
-            self::Urgent => 'Urgent',
-            self::Critical => 'Critical',
-        };
+        return __('escalated::enums.priority.'.$this->value);
     }
 
     public function color(): string

--- a/src/Enums/TicketStatus.php
+++ b/src/Enums/TicketStatus.php
@@ -15,16 +15,7 @@ enum TicketStatus: string
 
     public function label(): string
     {
-        return match ($this) {
-            self::Open => 'Open',
-            self::InProgress => 'In Progress',
-            self::WaitingOnCustomer => 'Waiting on Customer',
-            self::WaitingOnAgent => 'Waiting on Agent',
-            self::Escalated => 'Escalated',
-            self::Resolved => 'Resolved',
-            self::Closed => 'Closed',
-            self::Reopened => 'Reopened',
-        };
+        return __('escalated::enums.status.'.$this->value);
     }
 
     public function color(): string

--- a/src/EscalatedServiceProvider.php
+++ b/src/EscalatedServiceProvider.php
@@ -43,6 +43,8 @@ class EscalatedServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'escalated');
+
         $this->registerPublishing();
         $this->registerRoutes();
         $this->registerCommands();
@@ -72,6 +74,10 @@ class EscalatedServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../resources/views' => resource_path('views/vendor/escalated'),
         ], 'escalated-views');
+
+        $this->publishes([
+            __DIR__.'/../resources/lang' => $this->app->langPath('vendor/escalated'),
+        ], 'escalated-lang');
     }
 
     protected function registerRoutes(): void

--- a/src/Http/Controllers/AdminCannedResponseController.php
+++ b/src/Http/Controllers/AdminCannedResponseController.php
@@ -25,20 +25,20 @@ class AdminCannedResponseController extends Controller
             'created_by' => $request->user()->getKey(),
         ]));
 
-        return back()->with('success', 'Canned response created.');
+        return back()->with('success', __('escalated::messages.canned_response.created'));
     }
 
     public function update(CannedResponse $cannedResponse, StoreCannedResponseRequest $request): RedirectResponse
     {
         $cannedResponse->update($request->validated());
 
-        return back()->with('success', 'Canned response updated.');
+        return back()->with('success', __('escalated::messages.canned_response.updated'));
     }
 
     public function destroy(CannedResponse $cannedResponse): RedirectResponse
     {
         $cannedResponse->delete();
 
-        return back()->with('success', 'Canned response deleted.');
+        return back()->with('success', __('escalated::messages.canned_response.deleted'));
     }
 }

--- a/src/Http/Controllers/AdminDepartmentController.php
+++ b/src/Http/Controllers/AdminDepartmentController.php
@@ -27,7 +27,7 @@ class AdminDepartmentController extends Controller
     {
         Department::create($request->validated());
 
-        return redirect()->route('escalated.admin.departments.index')->with('success', 'Department created.');
+        return redirect()->route('escalated.admin.departments.index')->with('success', __('escalated::messages.department.created'));
     }
 
     public function edit(Department $department): Response
@@ -41,13 +41,13 @@ class AdminDepartmentController extends Controller
     {
         $department->update($request->validated());
 
-        return redirect()->route('escalated.admin.departments.index')->with('success', 'Department updated.');
+        return redirect()->route('escalated.admin.departments.index')->with('success', __('escalated::messages.department.updated'));
     }
 
     public function destroy(Department $department): RedirectResponse
     {
         $department->delete();
 
-        return redirect()->route('escalated.admin.departments.index')->with('success', 'Department deleted.');
+        return redirect()->route('escalated.admin.departments.index')->with('success', __('escalated::messages.department.deleted'));
     }
 }

--- a/src/Http/Controllers/AdminEscalationRuleController.php
+++ b/src/Http/Controllers/AdminEscalationRuleController.php
@@ -27,7 +27,7 @@ class AdminEscalationRuleController extends Controller
     {
         EscalationRule::create($request->validated());
 
-        return redirect()->route('escalated.admin.escalation-rules.index')->with('success', 'Rule created.');
+        return redirect()->route('escalated.admin.escalation-rules.index')->with('success', __('escalated::messages.escalation_rule.created'));
     }
 
     public function edit(EscalationRule $escalationRule): Response
@@ -39,13 +39,13 @@ class AdminEscalationRuleController extends Controller
     {
         $escalationRule->update($request->validated());
 
-        return redirect()->route('escalated.admin.escalation-rules.index')->with('success', 'Rule updated.');
+        return redirect()->route('escalated.admin.escalation-rules.index')->with('success', __('escalated::messages.escalation_rule.updated'));
     }
 
     public function destroy(EscalationRule $escalationRule): RedirectResponse
     {
         $escalationRule->delete();
 
-        return redirect()->route('escalated.admin.escalation-rules.index')->with('success', 'Rule deleted.');
+        return redirect()->route('escalated.admin.escalation-rules.index')->with('success', __('escalated::messages.escalation_rule.deleted'));
     }
 }

--- a/src/Http/Controllers/AdminMacroController.php
+++ b/src/Http/Controllers/AdminMacroController.php
@@ -26,20 +26,20 @@ class AdminMacroController extends Controller
             'created_by' => $request->user()->getKey(),
         ]);
 
-        return back()->with('success', 'Macro created.');
+        return back()->with('success', __('escalated::messages.macro.created'));
     }
 
     public function update(Macro $macro, StoreMacroRequest $request): RedirectResponse
     {
         $macro->update($request->validated());
 
-        return back()->with('success', 'Macro updated.');
+        return back()->with('success', __('escalated::messages.macro.updated'));
     }
 
     public function destroy(Macro $macro): RedirectResponse
     {
         $macro->delete();
 
-        return back()->with('success', 'Macro deleted.');
+        return back()->with('success', __('escalated::messages.macro.deleted'));
     }
 }

--- a/src/Http/Controllers/AdminSettingsController.php
+++ b/src/Http/Controllers/AdminSettingsController.php
@@ -51,7 +51,7 @@ class AdminSettingsController extends Controller
             EscalatedSettings::set($key, is_bool($value) ? ($value ? '1' : '0') : (string) $value);
         }
 
-        return redirect()->back()->with('success', 'Settings updated.');
+        return redirect()->back()->with('success', __('escalated::messages.settings.updated'));
     }
 
     protected function getSettings(): array

--- a/src/Http/Controllers/AdminSlaPolicyController.php
+++ b/src/Http/Controllers/AdminSlaPolicyController.php
@@ -27,7 +27,7 @@ class AdminSlaPolicyController extends Controller
     {
         SlaPolicy::create($request->validated());
 
-        return redirect()->route('escalated.admin.sla-policies.index')->with('success', 'SLA Policy created.');
+        return redirect()->route('escalated.admin.sla-policies.index')->with('success', __('escalated::messages.sla_policy.created'));
     }
 
     public function edit(SlaPolicy $slaPolicy): Response
@@ -41,13 +41,13 @@ class AdminSlaPolicyController extends Controller
     {
         $slaPolicy->update($request->validated());
 
-        return redirect()->route('escalated.admin.sla-policies.index')->with('success', 'SLA Policy updated.');
+        return redirect()->route('escalated.admin.sla-policies.index')->with('success', __('escalated::messages.sla_policy.updated'));
     }
 
     public function destroy(SlaPolicy $slaPolicy): RedirectResponse
     {
         $slaPolicy->delete();
 
-        return redirect()->route('escalated.admin.sla-policies.index')->with('success', 'SLA Policy deleted.');
+        return redirect()->route('escalated.admin.sla-policies.index')->with('success', __('escalated::messages.sla_policy.deleted'));
     }
 }

--- a/src/Http/Controllers/AdminTagController.php
+++ b/src/Http/Controllers/AdminTagController.php
@@ -20,20 +20,20 @@ class AdminTagController extends Controller
     {
         Tag::create($request->validated());
 
-        return back()->with('success', 'Tag created.');
+        return back()->with('success', __('escalated::messages.tag.created'));
     }
 
     public function update(Tag $tag, StoreTagRequest $request): RedirectResponse
     {
         $tag->update($request->validated());
 
-        return back()->with('success', 'Tag updated.');
+        return back()->with('success', __('escalated::messages.tag.updated'));
     }
 
     public function destroy(Tag $tag): RedirectResponse
     {
         $tag->delete();
 
-        return back()->with('success', 'Tag deleted.');
+        return back()->with('success', __('escalated::messages.tag.deleted'));
     }
 }

--- a/src/Http/Controllers/AdminTicketController.php
+++ b/src/Http/Controllers/AdminTicketController.php
@@ -74,35 +74,35 @@ class AdminTicketController extends Controller
     {
         $this->ticketService->reply($ticket, $request->user(), $request->validated('body'), $request->file('attachments', []));
 
-        return back()->with('success', 'Reply sent.');
+        return back()->with('success', __('escalated::messages.ticket.reply_sent'));
     }
 
     public function note(Ticket $ticket, ReplyToTicketRequest $request): RedirectResponse
     {
         $this->ticketService->addNote($ticket, $request->user(), $request->validated('body'), $request->file('attachments', []));
 
-        return back()->with('success', 'Note added.');
+        return back()->with('success', __('escalated::messages.ticket.note_added'));
     }
 
     public function assign(Ticket $ticket, AssignTicketRequest $request): RedirectResponse
     {
         $this->assignmentService->assign($ticket, $request->validated('agent_id'), $request->user());
 
-        return back()->with('success', 'Ticket assigned.');
+        return back()->with('success', __('escalated::messages.ticket.assigned'));
     }
 
     public function status(Ticket $ticket, ChangeStatusRequest $request): RedirectResponse
     {
         $this->ticketService->changeStatus($ticket, TicketStatus::from($request->validated('status')), $request->user());
 
-        return back()->with('success', 'Status updated.');
+        return back()->with('success', __('escalated::messages.ticket.status_updated'));
     }
 
     public function priority(Ticket $ticket, ChangePriorityRequest $request): RedirectResponse
     {
         $this->ticketService->changePriority($ticket, TicketPriority::from($request->validated('priority')), $request->user());
 
-        return back()->with('success', 'Priority updated.');
+        return back()->with('success', __('escalated::messages.ticket.priority_updated'));
     }
 
     public function tags(Ticket $ticket, UpdateTagsRequest $request): RedirectResponse
@@ -120,7 +120,7 @@ class AdminTicketController extends Controller
             $this->ticketService->removeTags($ticket, $toRemove, $request->user());
         }
 
-        return back()->with('success', 'Tags updated.');
+        return back()->with('success', __('escalated::messages.ticket.tags_updated'));
     }
 
     public function department(Ticket $ticket, Request $request): RedirectResponse
@@ -129,7 +129,7 @@ class AdminTicketController extends Controller
 
         $this->ticketService->changeDepartment($ticket, $request->integer('department_id'), $request->user());
 
-        return back()->with('success', 'Department updated.');
+        return back()->with('success', __('escalated::messages.ticket.department_updated'));
     }
 
     public function applyMacro(Ticket $ticket, Request $request, MacroService $macroService): RedirectResponse
@@ -139,7 +139,7 @@ class AdminTicketController extends Controller
         $macro = Macro::forAgent($request->user()->getKey())->findOrFail($request->integer('macro_id'));
         $macroService->apply($macro, $ticket, $request->user());
 
-        return back()->with('success', "Macro \"{$macro->name}\" applied.");
+        return back()->with('success', __('escalated::messages.ticket.macro_applied', ['name' => $macro->name]));
     }
 
     public function follow(Ticket $ticket, Request $request): RedirectResponse
@@ -149,12 +149,12 @@ class AdminTicketController extends Controller
         if ($ticket->isFollowedBy($userId)) {
             $ticket->unfollow($userId);
 
-            return back()->with('success', 'Unfollowed ticket.');
+            return back()->with('success', __('escalated::messages.ticket.unfollowed'));
         }
 
         $ticket->follow($userId);
 
-        return back()->with('success', 'Following ticket.');
+        return back()->with('success', __('escalated::messages.ticket.following'));
     }
 
     public function presence(Ticket $ticket, Request $request): \Illuminate\Http\JsonResponse
@@ -185,7 +185,7 @@ class AdminTicketController extends Controller
     public function pin(Ticket $ticket, Reply $reply, Request $request): RedirectResponse
     {
         if (! $reply->is_internal_note) {
-            return back()->with('error', 'Only internal notes can be pinned.');
+            return back()->with('error', __('escalated::messages.ticket.only_internal_notes_pinned'));
         }
 
         $reply->update(['is_pinned' => ! $reply->is_pinned]);

--- a/src/Http/Controllers/AgentTicketController.php
+++ b/src/Http/Controllers/AgentTicketController.php
@@ -72,42 +72,42 @@ class AgentTicketController extends Controller
     {
         $this->ticketService->update($ticket, $request->validated());
 
-        return back()->with('success', 'Ticket updated.');
+        return back()->with('success', __('escalated::messages.ticket.updated'));
     }
 
     public function reply(Ticket $ticket, ReplyToTicketRequest $request): RedirectResponse
     {
         $this->ticketService->reply($ticket, $request->user(), $request->validated('body'), $request->file('attachments', []));
 
-        return back()->with('success', 'Reply sent.');
+        return back()->with('success', __('escalated::messages.ticket.reply_sent'));
     }
 
     public function note(Ticket $ticket, ReplyToTicketRequest $request): RedirectResponse
     {
         $this->ticketService->addNote($ticket, $request->user(), $request->validated('body'), $request->file('attachments', []));
 
-        return back()->with('success', 'Note added.');
+        return back()->with('success', __('escalated::messages.ticket.note_added'));
     }
 
     public function assign(Ticket $ticket, AssignTicketRequest $request): RedirectResponse
     {
         $this->assignmentService->assign($ticket, $request->validated('agent_id'), $request->user());
 
-        return back()->with('success', 'Ticket assigned.');
+        return back()->with('success', __('escalated::messages.ticket.assigned'));
     }
 
     public function status(Ticket $ticket, ChangeStatusRequest $request): RedirectResponse
     {
         $this->ticketService->changeStatus($ticket, TicketStatus::from($request->validated('status')), $request->user());
 
-        return back()->with('success', 'Status updated.');
+        return back()->with('success', __('escalated::messages.ticket.status_updated'));
     }
 
     public function priority(Ticket $ticket, ChangePriorityRequest $request): RedirectResponse
     {
         $this->ticketService->changePriority($ticket, TicketPriority::from($request->validated('priority')), $request->user());
 
-        return back()->with('success', 'Priority updated.');
+        return back()->with('success', __('escalated::messages.ticket.priority_updated'));
     }
 
     public function tags(Ticket $ticket, UpdateTagsRequest $request): RedirectResponse
@@ -125,7 +125,7 @@ class AgentTicketController extends Controller
             $this->ticketService->removeTags($ticket, $toRemove, $request->user());
         }
 
-        return back()->with('success', 'Tags updated.');
+        return back()->with('success', __('escalated::messages.ticket.tags_updated'));
     }
 
     public function department(Ticket $ticket, Request $request): RedirectResponse
@@ -134,7 +134,7 @@ class AgentTicketController extends Controller
 
         $this->ticketService->changeDepartment($ticket, $request->integer('department_id'), $request->user());
 
-        return back()->with('success', 'Department updated.');
+        return back()->with('success', __('escalated::messages.ticket.department_updated'));
     }
 
     public function applyMacro(Ticket $ticket, Request $request, MacroService $macroService): RedirectResponse
@@ -144,7 +144,7 @@ class AgentTicketController extends Controller
         $macro = Macro::forAgent($request->user()->getKey())->findOrFail($request->integer('macro_id'));
         $macroService->apply($macro, $ticket, $request->user());
 
-        return back()->with('success', "Macro \"{$macro->name}\" applied.");
+        return back()->with('success', __('escalated::messages.ticket.macro_applied', ['name' => $macro->name]));
     }
 
     public function follow(Ticket $ticket, Request $request): RedirectResponse
@@ -154,12 +154,12 @@ class AgentTicketController extends Controller
         if ($ticket->isFollowedBy($userId)) {
             $ticket->unfollow($userId);
 
-            return back()->with('success', 'Unfollowed ticket.');
+            return back()->with('success', __('escalated::messages.ticket.unfollowed'));
         }
 
         $ticket->follow($userId);
 
-        return back()->with('success', 'Following ticket.');
+        return back()->with('success', __('escalated::messages.ticket.following'));
     }
 
     public function presence(Ticket $ticket, Request $request): \Illuminate\Http\JsonResponse
@@ -193,7 +193,7 @@ class AgentTicketController extends Controller
     public function pin(Ticket $ticket, Reply $reply, Request $request): RedirectResponse
     {
         if (! $reply->is_internal_note) {
-            return back()->with('error', 'Only internal notes can be pinned.');
+            return back()->with('error', __('escalated::messages.ticket.only_internal_notes_pinned'));
         }
 
         $reply->update(['is_pinned' => ! $reply->is_pinned]);

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -44,6 +44,6 @@ class BulkActionController extends Controller
             }
         }
 
-        return back()->with('success', "{$successCount} ticket(s) updated.");
+        return back()->with('success', __('escalated::messages.bulk.updated', ['count' => $successCount]));
     }
 }

--- a/src/Http/Controllers/CustomerTicketController.php
+++ b/src/Http/Controllers/CustomerTicketController.php
@@ -44,7 +44,7 @@ class CustomerTicketController extends Controller
 
         return redirect()
             ->route('escalated.customer.tickets.show', $ticket->reference)
-            ->with('success', 'Ticket created successfully.');
+            ->with('success', __('escalated::messages.ticket.created'));
     }
 
     public function show(Ticket $ticket, Request $request): Response
@@ -71,7 +71,7 @@ class CustomerTicketController extends Controller
             $request->file('attachments', [])
         );
 
-        return back()->with('success', 'Reply sent.');
+        return back()->with('success', __('escalated::messages.ticket.reply_sent'));
     }
 
     public function close(Ticket $ticket, Request $request): RedirectResponse
@@ -79,12 +79,12 @@ class CustomerTicketController extends Controller
         $this->authorizeCustomer($ticket, $request);
 
         if (! config('escalated.tickets.allow_customer_close')) {
-            abort(403, 'Customers cannot close tickets.');
+            abort(403, __('escalated::messages.ticket.customers_cannot_close'));
         }
 
         $this->ticketService->close($ticket, $request->user());
 
-        return back()->with('success', 'Ticket closed.');
+        return back()->with('success', __('escalated::messages.ticket.closed'));
     }
 
     public function reopen(Ticket $ticket, Request $request): RedirectResponse
@@ -93,7 +93,7 @@ class CustomerTicketController extends Controller
 
         $this->ticketService->reopen($ticket, $request->user());
 
-        return back()->with('success', 'Ticket reopened.');
+        return back()->with('success', __('escalated::messages.ticket.reopened'));
     }
 
     protected function authorizeCustomer(Ticket $ticket, Request $request): void

--- a/src/Http/Controllers/GuestTicketController.php
+++ b/src/Http/Controllers/GuestTicketController.php
@@ -75,7 +75,7 @@ class GuestTicketController extends Controller
 
         return redirect()
             ->route('escalated.guest.tickets.show', $ticket->guest_token)
-            ->with('success', 'Ticket created. Save this link to check your ticket status.');
+            ->with('success', __('escalated::messages.guest.created'));
     }
 
     public function show(string $token): Response
@@ -97,7 +97,7 @@ class GuestTicketController extends Controller
         $ticket = Ticket::where('guest_token', $token)->firstOrFail();
 
         if ($ticket->status === TicketStatus::Closed) {
-            return back()->with('error', 'This ticket is closed.');
+            return back()->with('error', __('escalated::messages.guest.ticket_closed'));
         }
 
         $validated = $request->validate([
@@ -121,6 +121,6 @@ class GuestTicketController extends Controller
 
         Events\ReplyCreated::dispatch($reply);
 
-        return back()->with('success', 'Reply sent.');
+        return back()->with('success', __('escalated::messages.ticket.reply_sent'));
     }
 }

--- a/src/Http/Controllers/InboundEmailController.php
+++ b/src/Http/Controllers/InboundEmailController.php
@@ -26,14 +26,14 @@ class InboundEmailController extends Controller
     {
         // Verify inbound email is enabled
         if (! EscalatedSettings::getBool('inbound_email_enabled', (bool) config('escalated.inbound_email.enabled', false))) {
-            return response()->json(['error' => 'Inbound email is disabled.'], 404);
+            return response()->json(['error' => __('escalated::messages.inbound_email.disabled')], 404);
         }
 
         // Resolve the adapter
         $adapterInstance = $this->resolveAdapter($adapter);
 
         if (! $adapterInstance) {
-            return response()->json(['error' => 'Unknown adapter.'], 400);
+            return response()->json(['error' => __('escalated::messages.inbound_email.unknown_adapter')], 400);
         }
 
         // Verify the request authenticity
@@ -43,7 +43,7 @@ class InboundEmailController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json(['error' => 'Invalid signature.'], 403);
+            return response()->json(['error' => __('escalated::messages.inbound_email.invalid_signature')], 403);
         }
 
         try {
@@ -60,7 +60,7 @@ class InboundEmailController extends Controller
                 'error' => $e->getMessage(),
             ]);
 
-            return response()->json(['error' => 'Processing failed.'], 500);
+            return response()->json(['error' => __('escalated::messages.inbound_email.processing_failed')], 500);
         }
     }
 

--- a/src/Http/Controllers/SatisfactionRatingController.php
+++ b/src/Http/Controllers/SatisfactionRatingController.php
@@ -18,11 +18,11 @@ class SatisfactionRatingController extends Controller
         ]);
 
         if (! in_array($ticket->status->value, ['resolved', 'closed'])) {
-            return back()->with('error', 'You can only rate resolved or closed tickets.');
+            return back()->with('error', __('escalated::messages.rating.only_resolved_closed'));
         }
 
         if ($ticket->satisfactionRating()->exists()) {
-            return back()->with('error', 'This ticket has already been rated.');
+            return back()->with('error', __('escalated::messages.rating.already_rated'));
         }
 
         SatisfactionRating::create([
@@ -33,7 +33,7 @@ class SatisfactionRatingController extends Controller
             'rated_by_id' => $request->user()?->getKey(),
         ]);
 
-        return back()->with('success', 'Thank you for your feedback!');
+        return back()->with('success', __('escalated::messages.rating.thanks'));
     }
 
     public function storeGuest(string $token, Request $request): RedirectResponse
@@ -46,11 +46,11 @@ class SatisfactionRatingController extends Controller
         $ticket = Ticket::where('guest_token', $token)->firstOrFail();
 
         if (! in_array($ticket->status->value, ['resolved', 'closed'])) {
-            return back()->with('error', 'You can only rate resolved or closed tickets.');
+            return back()->with('error', __('escalated::messages.rating.only_resolved_closed'));
         }
 
         if ($ticket->satisfactionRating()->exists()) {
-            return back()->with('error', 'This ticket has already been rated.');
+            return back()->with('error', __('escalated::messages.rating.already_rated'));
         }
 
         SatisfactionRating::create([
@@ -59,6 +59,6 @@ class SatisfactionRatingController extends Controller
             'comment' => $request->input('comment'),
         ]);
 
-        return back()->with('success', 'Thank you for your feedback!');
+        return back()->with('success', __('escalated::messages.rating.thanks'));
     }
 }

--- a/src/Http/Middleware/EnsureIsAdmin.php
+++ b/src/Http/Middleware/EnsureIsAdmin.php
@@ -14,7 +14,7 @@ class EnsureIsAdmin
         $gate = config('escalated.authorization.admin_gate', 'escalated-admin');
 
         if (! Gate::check($gate)) {
-            abort(403, 'You are not authorized as a support administrator.');
+            abort(403, __('escalated::messages.middleware.not_admin'));
         }
 
         return $next($request);

--- a/src/Http/Middleware/EnsureIsAgent.php
+++ b/src/Http/Middleware/EnsureIsAgent.php
@@ -14,7 +14,7 @@ class EnsureIsAgent
         $gate = config('escalated.authorization.agent_gate', 'escalated-agent');
 
         if (! Gate::check($gate)) {
-            abort(403, 'You are not authorized as a support agent.');
+            abort(403, __('escalated::messages.middleware.not_agent'));
         }
 
         return $next($request);

--- a/src/Notifications/NewTicketNotification.php
+++ b/src/Notifications/NewTicketNotification.php
@@ -22,12 +22,15 @@ class NewTicketNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("[{$this->ticket->reference}] New Ticket: {$this->ticket->subject}")
-            ->line("A new support ticket has been created.")
-            ->line("**Subject:** {$this->ticket->subject}")
-            ->line("**Priority:** {$this->ticket->priority->label()}")
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/'.$this->ticket->reference))
-            ->line('Thank you for using our support system.');
+            ->subject(__('escalated::notifications.new_ticket.subject', [
+                'reference' => $this->ticket->reference,
+                'subject' => $this->ticket->subject,
+            ]))
+            ->line(__('escalated::notifications.new_ticket.line1'))
+            ->line(__('escalated::notifications.new_ticket.subject_line', ['subject' => $this->ticket->subject]))
+            ->line(__('escalated::notifications.new_ticket.priority_line', ['priority' => $this->ticket->priority->label()]))
+            ->action(__('escalated::notifications.new_ticket.action'), url(config('escalated.routes.prefix').'/'.$this->ticket->reference))
+            ->line(__('escalated::notifications.new_ticket.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/src/Notifications/SlaBreachNotification.php
+++ b/src/Notifications/SlaBreachNotification.php
@@ -24,16 +24,21 @@ class SlaBreachNotification extends Notification implements ShouldQueue
 
     public function toMail(object $notifiable): MailMessage
     {
-        $typeLabel = $this->breachType === 'first_response' ? 'First Response' : 'Resolution';
+        $typeLabel = $this->breachType === 'first_response'
+            ? __('escalated::notifications.sla_breach.type_first_response')
+            : __('escalated::notifications.sla_breach.type_resolution');
 
         return (new MailMessage)
-            ->subject("[SLA Breach] [{$this->ticket->reference}] {$typeLabel} SLA Breached")
-            ->line("An SLA has been breached on ticket {$this->ticket->reference}.")
-            ->line("**Type:** {$typeLabel} SLA")
-            ->line("**Subject:** {$this->ticket->subject}")
-            ->line("**Priority:** {$this->ticket->priority->label()}")
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/agent/tickets/'.$this->ticket->reference))
-            ->line('Immediate attention is required.');
+            ->subject(__('escalated::notifications.sla_breach.subject', [
+                'reference' => $this->ticket->reference,
+                'type' => $typeLabel,
+            ]))
+            ->line(__('escalated::notifications.sla_breach.line1', ['reference' => $this->ticket->reference]))
+            ->line(__('escalated::notifications.sla_breach.type_line', ['type' => $typeLabel]))
+            ->line(__('escalated::notifications.sla_breach.subject_line', ['subject' => $this->ticket->subject]))
+            ->line(__('escalated::notifications.sla_breach.priority_line', ['priority' => $this->ticket->priority->label()]))
+            ->action(__('escalated::notifications.sla_breach.action'), url(config('escalated.routes.prefix').'/agent/tickets/'.$this->ticket->reference))
+            ->line(__('escalated::notifications.sla_breach.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/src/Notifications/TicketAssignedNotification.php
+++ b/src/Notifications/TicketAssignedNotification.php
@@ -22,12 +22,14 @@ class TicketAssignedNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("[{$this->ticket->reference}] Ticket Assigned to You")
-            ->line("A ticket has been assigned to you.")
-            ->line("**Subject:** {$this->ticket->subject}")
-            ->line("**Priority:** {$this->ticket->priority->label()}")
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/agent/tickets/'.$this->ticket->reference))
-            ->line('Please review and respond at your earliest convenience.');
+            ->subject(__('escalated::notifications.ticket_assigned.subject', [
+                'reference' => $this->ticket->reference,
+            ]))
+            ->line(__('escalated::notifications.ticket_assigned.line1'))
+            ->line(__('escalated::notifications.ticket_assigned.subject_line', ['subject' => $this->ticket->subject]))
+            ->line(__('escalated::notifications.ticket_assigned.priority_line', ['priority' => $this->ticket->priority->label()]))
+            ->action(__('escalated::notifications.ticket_assigned.action'), url(config('escalated.routes.prefix').'/agent/tickets/'.$this->ticket->reference))
+            ->line(__('escalated::notifications.ticket_assigned.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/src/Notifications/TicketEscalatedNotification.php
+++ b/src/Notifications/TicketEscalatedNotification.php
@@ -25,18 +25,21 @@ class TicketEscalatedNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         $mail = (new MailMessage)
-            ->subject("[Escalated] [{$this->ticket->reference}] {$this->ticket->subject}")
-            ->line("A ticket has been escalated.")
-            ->line("**Subject:** {$this->ticket->subject}")
-            ->line("**Priority:** {$this->ticket->priority->label()}");
+            ->subject(__('escalated::notifications.ticket_escalated.subject', [
+                'reference' => $this->ticket->reference,
+                'subject' => $this->ticket->subject,
+            ]))
+            ->line(__('escalated::notifications.ticket_escalated.line1'))
+            ->line(__('escalated::notifications.ticket_escalated.subject_line', ['subject' => $this->ticket->subject]))
+            ->line(__('escalated::notifications.ticket_escalated.priority_line', ['priority' => $this->ticket->priority->label()]));
 
         if ($this->reason) {
-            $mail->line("**Reason:** {$this->reason}");
+            $mail->line(__('escalated::notifications.ticket_escalated.reason_line', ['reason' => $this->reason]));
         }
 
         return $mail
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/agent/tickets/'.$this->ticket->reference))
-            ->line('Immediate attention is required.');
+            ->action(__('escalated::notifications.ticket_escalated.action'), url(config('escalated.routes.prefix').'/agent/tickets/'.$this->ticket->reference))
+            ->line(__('escalated::notifications.ticket_escalated.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/src/Notifications/TicketReplyNotification.php
+++ b/src/Notifications/TicketReplyNotification.php
@@ -24,11 +24,14 @@ class TicketReplyNotification extends Notification implements ShouldQueue
         $ticket = $this->reply->ticket;
 
         return (new MailMessage)
-            ->subject("Re: [{$ticket->reference}] {$ticket->subject}")
-            ->line("A new reply has been added to your ticket.")
+            ->subject(__('escalated::notifications.ticket_reply.subject', [
+                'reference' => $ticket->reference,
+                'subject' => $ticket->subject,
+            ]))
+            ->line(__('escalated::notifications.ticket_reply.line1'))
             ->line($this->reply->body)
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/'.$ticket->reference))
-            ->line('Thank you for using our support system.');
+            ->action(__('escalated::notifications.ticket_reply.action'), url(config('escalated.routes.prefix').'/'.$ticket->reference))
+            ->line(__('escalated::notifications.ticket_reply.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/src/Notifications/TicketResolvedNotification.php
+++ b/src/Notifications/TicketResolvedNotification.php
@@ -22,12 +22,14 @@ class TicketResolvedNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("[{$this->ticket->reference}] Ticket Resolved")
-            ->line("Your support ticket has been resolved.")
-            ->line("**Subject:** {$this->ticket->subject}")
-            ->line("If you need further assistance, you can reopen this ticket.")
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/'.$this->ticket->reference))
-            ->line('Thank you for using our support system.');
+            ->subject(__('escalated::notifications.ticket_resolved.subject', [
+                'reference' => $this->ticket->reference,
+            ]))
+            ->line(__('escalated::notifications.ticket_resolved.line1'))
+            ->line(__('escalated::notifications.ticket_resolved.subject_line', ['subject' => $this->ticket->subject]))
+            ->line(__('escalated::notifications.ticket_resolved.reopen_line'))
+            ->action(__('escalated::notifications.ticket_resolved.action'), url(config('escalated.routes.prefix').'/'.$this->ticket->reference))
+            ->line(__('escalated::notifications.ticket_resolved.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/src/Notifications/TicketStatusChangedNotification.php
+++ b/src/Notifications/TicketStatusChangedNotification.php
@@ -27,12 +27,15 @@ class TicketStatusChangedNotification extends Notification implements ShouldQueu
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("[{$this->ticket->reference}] Status Updated: {$this->newStatus->label()}")
-            ->line("The status of your ticket has been updated.")
-            ->line("**From:** {$this->oldStatus->label()}")
-            ->line("**To:** {$this->newStatus->label()}")
-            ->action('View Ticket', url(config('escalated.routes.prefix').'/'.$this->ticket->reference))
-            ->line('Thank you for using our support system.');
+            ->subject(__('escalated::notifications.ticket_status_changed.subject', [
+                'reference' => $this->ticket->reference,
+                'status' => $this->newStatus->label(),
+            ]))
+            ->line(__('escalated::notifications.ticket_status_changed.line1'))
+            ->line(__('escalated::notifications.ticket_status_changed.from_line', ['status' => $this->oldStatus->label()]))
+            ->line(__('escalated::notifications.ticket_status_changed.to_line', ['status' => $this->newStatus->label()]))
+            ->action(__('escalated::notifications.ticket_status_changed.action'), url(config('escalated.routes.prefix').'/'.$this->ticket->reference))
+            ->line(__('escalated::notifications.ticket_status_changed.closing'));
     }
 
     public function toArray(object $notifiable): array

--- a/tests/Feature/NotificationTranslationTest.php
+++ b/tests/Feature/NotificationTranslationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Escalated\Laravel\Enums\TicketPriority;
+use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Notifications\NewTicketNotification;
+use Escalated\Laravel\Notifications\SlaBreachNotification;
+use Escalated\Laravel\Notifications\TicketAssignedNotification;
+use Escalated\Laravel\Notifications\TicketEscalatedNotification;
+use Escalated\Laravel\Notifications\TicketResolvedNotification;
+use Escalated\Laravel\Notifications\TicketStatusChangedNotification;
+use Illuminate\Support\Facades\App;
+
+beforeEach(function () {
+    $this->user = $this->createTestUser();
+    $this->ticket = Ticket::factory()->forRequester(get_class($this->user), $this->user->id)->create([
+        'reference' => 'TK-001',
+        'subject' => 'Test Ticket',
+    ]);
+});
+
+it('translates new ticket notification subject', function () {
+    $notification = new NewTicketNotification($this->ticket);
+
+    App::setLocale('en');
+    $mailEn = $notification->toMail($this->user);
+    expect($mailEn->subject)->toContain('New Ticket');
+
+    App::setLocale('es');
+    $mailEs = $notification->toMail($this->user);
+    expect($mailEs->subject)->toContain('Nuevo ticket');
+
+    App::setLocale('fr');
+    $mailFr = $notification->toMail($this->user);
+    expect($mailFr->subject)->toContain('Nouveau ticket');
+
+    App::setLocale('de');
+    $mailDe = $notification->toMail($this->user);
+    expect($mailDe->subject)->toContain('Neues Ticket');
+});
+
+it('translates ticket assigned notification subject', function () {
+    $notification = new TicketAssignedNotification($this->ticket);
+
+    App::setLocale('en');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Assigned to You');
+
+    App::setLocale('es');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('asignado a usted');
+});
+
+it('translates ticket resolved notification subject', function () {
+    $notification = new TicketResolvedNotification($this->ticket);
+
+    App::setLocale('en');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Ticket Resolved');
+
+    App::setLocale('de');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Ticket gelöst');
+});
+
+it('translates status changed notification subject', function () {
+    $notification = new TicketStatusChangedNotification(
+        $this->ticket,
+        TicketStatus::Open,
+        TicketStatus::InProgress,
+    );
+
+    App::setLocale('en');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Status Updated');
+
+    App::setLocale('fr');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Statut mis à jour');
+});
+
+it('translates SLA breach notification subject', function () {
+    $notification = new SlaBreachNotification($this->ticket, 'first_response');
+
+    App::setLocale('en');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('SLA Breach');
+    expect($mail->subject)->toContain('First Response');
+
+    App::setLocale('es');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Incumplimiento SLA');
+    expect($mail->subject)->toContain('Primera respuesta');
+});
+
+it('translates escalated notification subject', function () {
+    $notification = new TicketEscalatedNotification($this->ticket, 'High priority');
+
+    App::setLocale('en');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Escalated');
+
+    App::setLocale('de');
+    $mail = $notification->toMail($this->user);
+    expect($mail->subject)->toContain('Eskaliert');
+});
+
+it('translates notification action text', function () {
+    $notification = new NewTicketNotification($this->ticket);
+
+    App::setLocale('en');
+    $mail = $notification->toMail($this->user);
+    expect($mail->actionText)->toBe('View Ticket');
+
+    App::setLocale('es');
+    $mail = $notification->toMail($this->user);
+    expect($mail->actionText)->toBe('Ver ticket');
+
+    App::setLocale('fr');
+    $mail = $notification->toMail($this->user);
+    expect($mail->actionText)->toBe('Voir le ticket');
+
+    App::setLocale('de');
+    $mail = $notification->toMail($this->user);
+    expect($mail->actionText)->toBe('Ticket ansehen');
+});
+
+it('does not translate toArray output', function () {
+    $notification = new NewTicketNotification($this->ticket);
+
+    App::setLocale('es');
+    $array = $notification->toArray($this->user);
+
+    expect($array['type'])->toBe('new_ticket');
+    expect($array['reference'])->toBe('TK-001');
+});

--- a/tests/Unit/TranslationTest.php
+++ b/tests/Unit/TranslationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\File;
+
+$locales = ['en', 'es', 'fr', 'de'];
+$langFiles = ['enums', 'notifications', 'emails', 'messages', 'commands'];
+
+it('has all language files for every locale', function () use ($locales, $langFiles) {
+    $langPath = __DIR__.'/../../resources/lang';
+
+    foreach ($locales as $locale) {
+        foreach ($langFiles as $file) {
+            $filePath = "{$langPath}/{$locale}/{$file}.php";
+            expect(file_exists($filePath))
+                ->toBeTrue("Missing language file: {$locale}/{$file}.php");
+        }
+    }
+});
+
+it('has identical key sets across all locales', function () use ($locales, $langFiles) {
+    $langPath = __DIR__.'/../../resources/lang';
+
+    foreach ($langFiles as $file) {
+        $referenceKeys = null;
+        $referenceLocale = null;
+
+        foreach ($locales as $locale) {
+            $filePath = "{$langPath}/{$locale}/{$file}.php";
+            $translations = require $filePath;
+            $keys = array_keys(Arr::dot($translations));
+            sort($keys);
+
+            if ($referenceKeys === null) {
+                $referenceKeys = $keys;
+                $referenceLocale = $locale;
+                continue;
+            }
+
+            $missing = array_diff($referenceKeys, $keys);
+            $extra = array_diff($keys, $referenceKeys);
+
+            expect($missing)
+                ->toBeEmpty("Missing keys in {$locale}/{$file}.php (present in {$referenceLocale}): ".implode(', ', $missing));
+
+            expect($extra)
+                ->toBeEmpty("Extra keys in {$locale}/{$file}.php (not in {$referenceLocale}): ".implode(', ', $extra));
+        }
+    }
+});
+
+it('has no empty translation values', function () use ($locales, $langFiles) {
+    $langPath = __DIR__.'/../../resources/lang';
+
+    foreach ($locales as $locale) {
+        foreach ($langFiles as $file) {
+            $filePath = "{$langPath}/{$locale}/{$file}.php";
+            $translations = require $filePath;
+            $dotted = Arr::dot($translations);
+
+            foreach ($dotted as $key => $value) {
+                expect($value)
+                    ->not->toBeEmpty("Empty translation value: {$locale}/{$file}.php → {$key}");
+            }
+        }
+    }
+});
+
+it('preserves placeholder patterns across locales', function () use ($locales, $langFiles) {
+    $langPath = __DIR__.'/../../resources/lang';
+
+    foreach ($langFiles as $file) {
+        $enFilePath = "{$langPath}/en/{$file}.php";
+        $enTranslations = Arr::dot(require $enFilePath);
+
+        foreach ($locales as $locale) {
+            if ($locale === 'en') {
+                continue;
+            }
+
+            $localeFilePath = "{$langPath}/{$locale}/{$file}.php";
+            $localeTranslations = Arr::dot(require $localeFilePath);
+
+            foreach ($enTranslations as $key => $enValue) {
+                preg_match_all('/:(\w+)/', $enValue, $enMatches);
+                $enPlaceholders = $enMatches[1];
+
+                if (empty($enPlaceholders)) {
+                    continue;
+                }
+
+                $localeValue = $localeTranslations[$key] ?? '';
+                preg_match_all('/:(\w+)/', $localeValue, $localeMatches);
+                $localePlaceholders = $localeMatches[1];
+
+                sort($enPlaceholders);
+                sort($localePlaceholders);
+
+                expect($localePlaceholders)
+                    ->toBe($enPlaceholders, "Placeholder mismatch in {$locale}/{$file}.php → {$key}");
+            }
+        }
+    }
+});

--- a/tests/Unit/TranslationUsageTest.php
+++ b/tests/Unit/TranslationUsageTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Escalated\Laravel\Enums\ActivityType;
+use Escalated\Laravel\Enums\TicketPriority;
+use Escalated\Laravel\Enums\TicketStatus;
+use Illuminate\Support\Facades\App;
+
+it('translates ticket status labels based on locale', function () {
+    App::setLocale('en');
+    expect(TicketStatus::Open->label())->toBe('Open');
+    expect(TicketStatus::InProgress->label())->toBe('In Progress');
+    expect(TicketStatus::WaitingOnCustomer->label())->toBe('Waiting on Customer');
+
+    App::setLocale('es');
+    expect(TicketStatus::Open->label())->toBe('Abierto');
+    expect(TicketStatus::InProgress->label())->toBe('En progreso');
+    expect(TicketStatus::WaitingOnCustomer->label())->toBe('Esperando al cliente');
+
+    App::setLocale('fr');
+    expect(TicketStatus::Open->label())->toBe('Ouvert');
+    expect(TicketStatus::InProgress->label())->toBe('En cours');
+
+    App::setLocale('de');
+    expect(TicketStatus::Open->label())->toBe('Offen');
+    expect(TicketStatus::InProgress->label())->toBe('In Bearbeitung');
+});
+
+it('translates ticket priority labels based on locale', function () {
+    App::setLocale('en');
+    expect(TicketPriority::Low->label())->toBe('Low');
+    expect(TicketPriority::Critical->label())->toBe('Critical');
+
+    App::setLocale('es');
+    expect(TicketPriority::Low->label())->toBe('Bajo');
+    expect(TicketPriority::Critical->label())->toBe('Crítico');
+
+    App::setLocale('fr');
+    expect(TicketPriority::Low->label())->toBe('Bas');
+    expect(TicketPriority::Critical->label())->toBe('Critique');
+
+    App::setLocale('de');
+    expect(TicketPriority::Low->label())->toBe('Niedrig');
+    expect(TicketPriority::Critical->label())->toBe('Kritisch');
+});
+
+it('translates activity type labels based on locale', function () {
+    App::setLocale('en');
+    expect(ActivityType::SlaBreached->label())->toBe('SLA Breached');
+    expect(ActivityType::StatusChanged->label())->toBe('Status Changed');
+
+    App::setLocale('es');
+    expect(ActivityType::SlaBreached->label())->toBe('SLA incumplido');
+    expect(ActivityType::StatusChanged->label())->toBe('Estado cambiado');
+
+    App::setLocale('fr');
+    expect(ActivityType::SlaBreached->label())->toBe('SLA non respecté');
+
+    App::setLocale('de');
+    expect(ActivityType::SlaBreached->label())->toBe('SLA verletzt');
+});
+
+it('returns all status labels for each locale', function () {
+    foreach (['en', 'es', 'fr', 'de'] as $locale) {
+        App::setLocale($locale);
+
+        foreach (TicketStatus::cases() as $status) {
+            $label = $status->label();
+            expect($label)->toBeString();
+            expect($label)->not->toContain('escalated::');
+        }
+    }
+});
+
+it('returns all priority labels for each locale', function () {
+    foreach (['en', 'es', 'fr', 'de'] as $locale) {
+        App::setLocale($locale);
+
+        foreach (TicketPriority::cases() as $priority) {
+            $label = $priority->label();
+            expect($label)->toBeString();
+            expect($label)->not->toContain('escalated::');
+        }
+    }
+});
+
+it('returns all activity type labels for each locale', function () {
+    foreach (['en', 'es', 'fr', 'de'] as $locale) {
+        App::setLocale($locale);
+
+        foreach (ActivityType::cases() as $type) {
+            $label = $type->label();
+            expect($label)->toBeString();
+            expect($label)->not->toContain('escalated::');
+        }
+    }
+});
+
+it('fixes SLA breached casing issue', function () {
+    App::setLocale('en');
+    expect(ActivityType::SlaBreached->label())->toBe('SLA Breached');
+});


### PR DESCRIPTION
Replace ~160 hardcoded English strings across enums, notifications, email templates, controllers, middleware, and console commands with Laravel's __() translation helper.

- Add translation files for 4 locales (en, es, fr, de) covering enums, notifications, emails, messages, and commands
- Register package translations in service provider with publishable tag
- Update enum label() methods to use translation keys
- Translate all notification toMail() subjects, lines, and actions
- Translate email blade templates with __() calls
- Translate controller flash messages and middleware abort messages
- Add translation completeness, usage, and notification tests