### PR TITLE
fix: update Inertia render path for Plugins page to match other backends

### DIFF
--- a/src/Http/Controllers/Admin/PluginController.php
+++ b/src/Http/Controllers/Admin/PluginController.php
@@ -24,7 +24,7 @@ class PluginController extends Controller
     {
         $plugins = $this->pluginService->getAllPlugins();
 
-        return Inertia::render('Escalated/Admin/Plugins', [
+        return Inertia::render('Escalated/Admin/Plugins/Index', [
             'plugins' => $plugins,
         ]);
     }


### PR DESCRIPTION
Change Escalated/Admin/Plugins to Escalated/Admin/Plugins/Index to align with Adonis, Django, and Rails backends. The old flat Plugins.vue has been removed from the shared frontend package.