### PR TITLE
docs: add translated READMEs (13 languages)

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <b>العربية</b> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## الميزات
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## المتطلبات
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## البدء السريع
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## تكامل الواجهة الأمامية
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## أوضاع الاستضافة
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## نشر الأصول
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## الجدولة
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## الإعدادات
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## الأحداث
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## البريد الوارد
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## المسارات
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -522,7 +522,7 @@ class MyAdapter implements InboundAdapter
 
 All routes use the configurable prefix (default: `support`). Inbound webhook routes use the `api` middleware (no auth, no CSRF).
 
-## Plugin SDK
+## حزمة SDK للإضافات
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## جسر الإضافات (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## التوثيق
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## الاختبار
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## متوفر أيضاً لـ
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## الرخصة
 
 MIT

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <b>Deutsch</b> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funktionen
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Voraussetzungen
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Schnellstart
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Frontend-Integration
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Hosting-Modi
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Assets veröffentlichen
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Planung
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Konfiguration
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Ereignisse
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Eingehende E-Mails
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Routen
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Plugin-Brücke (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Dokumentation
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Testen
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Auch verfügbar für
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Lizenz
 
 MIT

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <b>Español</b> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Características
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Requisitos
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Inicio Rápido
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Integración Frontend
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Modos de Hospedaje
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Publicar Assets
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Programación
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Configuración
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Eventos
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Correo Entrante
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Rutas
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Puente de Plugins (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Documentación
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Pruebas
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## También Disponible Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licencia
 
 MIT

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <b>Français</b> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Fonctionnalités
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Prérequis
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Démarrage Rapide
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Intégration Frontend
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Modes d'Hébergement
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Publication des Assets
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Planification
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Événements
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## E-mail Entrant
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Pont de Plugins (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Tests
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Également Disponible Pour
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licence
 
 MIT

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <b>Italiano</b> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funzionalità
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Requisiti
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Avvio Rapido
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Integrazione Frontend
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Modalità di Hosting
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Pubblicazione Assets
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Pianificazione
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Configurazione
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Eventi
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Email in Entrata
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Route
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Bridge dei Plugin (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Documentazione
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Test
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Disponibile Anche Per
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licenza
 
 MIT

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <b>日本語</b> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 機能
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## 要件
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## クイックスタート
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## フロントエンド統合
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## ホスティングモード
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## アセットの公開
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## スケジューリング
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## 設定
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## イベント
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## 受信メール
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## ルート
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -522,7 +522,7 @@ class MyAdapter implements InboundAdapter
 
 All routes use the configurable prefix (default: `support`). Inbound webhook routes use the `api` middleware (no auth, no CSRF).
 
-## Plugin SDK
+## プラグインSDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## プラグインブリッジ (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## ドキュメント
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## テスト
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## 他のフレームワーク向け
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## ライセンス
 
 MIT

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <b>한국어</b> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 기능
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## 요구 사항
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## 빠른 시작
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## 프론트엔드 통합
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## 호스팅 모드
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## 에셋 발행
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## 스케줄링
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## 설정
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## 이벤트
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## 수신 이메일
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## 라우트
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -522,7 +522,7 @@ class MyAdapter implements InboundAdapter
 
 All routes use the configurable prefix (default: `support`). Inbound webhook routes use the `api` middleware (no auth, no CSRF).
 
-## Plugin SDK
+## 플러그인 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## 플러그인 브리지 (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## 문서
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## 테스트
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## 다른 프레임워크에서도 사용 가능
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## 라이선스
 
 MIT

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <b>Nederlands</b> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Functies
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Vereisten
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Snel Starten
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Frontend-integratie
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Hostingmodi
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Assets Publiceren
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Planning
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Configuratie
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Gebeurtenissen
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Inkomende E-mail
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Plugin-brug (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Documentatie
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Testen
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Ook Beschikbaar Voor
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licentie
 
 MIT

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <b>Polski</b> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funkcje
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Wymagania
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Szybki Start
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Integracja Frontend
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Tryby Hostingu
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Publikacja Zasobów
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Harmonogram
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Konfiguracja
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Zdarzenia
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Poczta Przychodząca
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Trasy
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Most Pluginów (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Dokumentacja
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Testowanie
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Dostępne Również Dla
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licencja
 
 MIT

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <b>Português (BR)</b> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Recursos
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Requisitos
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Início Rápido
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Integração Frontend
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Modos de Hospedagem
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Publicação de Assets
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Agendamento
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Configuração
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Eventos
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## E-mail de Entrada
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Rotas
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Ponte de Plugins (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Documentação
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Testes
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Também Disponível Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Licença
 
 MIT

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <b>Русский</b> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Возможности
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Требования
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Быстрый старт
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Интеграция фронтенда
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Режимы хостинга
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Публикация ресурсов
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Планирование
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Конфигурация
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## События
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Входящая почта
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Маршруты
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Мост плагинов (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Документация
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Тестирование
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Также доступно для
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Лицензия
 
 MIT

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <b>Türkçe</b> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Özellikler
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## Gereksinimler
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Hızlı Başlangıç
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## Frontend Entegrasyonu
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## Barındırma Modları
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## Varlıkları Yayınlama
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## Zamanlama
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## Yapılandırma
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## Olaylar
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## Gelen E-posta
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## Rotalar
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## Plugin Köprüsü (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## Dokümantasyon
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## Test
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## Şunlar İçin de Mevcut
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## Lisans
 
 MIT

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <b>简体中文</b>
 </p>
 
 # Escalated for Laravel
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 功能特性
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -54,13 +54,13 @@ A full-featured, embeddable support ticket system for Laravel. Drop it into any 
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 - **CI: Laravel Pint** — Automated code style enforcement on every pull request
 
-## Requirements
+## 系统要求
 
 - PHP 8.2+
 - Laravel 11.x, 12.x, or 13.x
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## 快速开始
 
 ```bash
 composer require escalated-dev/escalated-laravel
@@ -92,7 +92,7 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin
 
 Visit `/support` — you're live.
 
-## Frontend Integration
+## 前端集成
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
 
@@ -215,7 +215,7 @@ page.props.escalated = {
 
 Use these to conditionally show nav links or restrict UI elements.
 
-## Hosting Modes
+## 托管模式
 
 ### Self-Hosted (default)
 
@@ -248,7 +248,7 @@ All ticket data proxied to the cloud API. Your app handles auth and renders UI, 
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Publishing Assets
+## 发布资源
 
 ```bash
 # Email templates
@@ -261,7 +261,7 @@ php artisan vendor:publish --tag=escalated-config
 php artisan vendor:publish --tag=escalated-migrations
 ```
 
-## Scheduling
+## 调度
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -274,7 +274,7 @@ Schedule::command('escalated:purge-activities')->weekly();
 Schedule::command('escalated:poll-imap')->everyMinute(); // Only if using IMAP adapter
 ```
 
-## Configuration
+## 配置
 
 All config lives in `config/escalated.php`. Key options:
 
@@ -308,7 +308,7 @@ All config lives in `config/escalated.php`. Key options:
 
 See the [full configuration reference](docs/configuration.md).
 
-## Events
+## 事件
 
 Every ticket action dispatches an event you can listen to:
 
@@ -334,7 +334,7 @@ Event::listen(TicketCreated::class, function ($event) {
 
 [Full events documentation →](docs/events.md)
 
-## Inbound Email
+## 入站邮件
 
 Escalated can create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling as a fallback.
 
@@ -492,7 +492,7 @@ class MyAdapter implements InboundAdapter
 | `ESCALATED_IMAP_PASSWORD` | — | IMAP password |
 | `ESCALATED_IMAP_MAILBOX` | `INBOX` | IMAP mailbox to poll |
 
-## Routes
+## 路由
 
 | Route | Method | Description |
 |-------|--------|-------------|
@@ -522,7 +522,7 @@ class MyAdapter implements InboundAdapter
 
 All routes use the configurable prefix (default: `support`). Inbound webhook routes use the `api` middleware (no auth, no CSRF).
 
-## Plugin SDK
+## 插件 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -574,7 +574,7 @@ export default definePlugin({
 
 See the detailed [Plugin Bridge](#plugin-bridge-sdk-plugins) section below for the full architecture, auto-generated routes, dual dispatch, and store documentation.
 
-## Plugin Bridge (SDK Plugins)
+## 插件桥接 (SDK Plugins)
 
 Escalated supports a second generation of plugins written in TypeScript using the `@escalated-dev/plugin-sdk`. These plugins run as a Node.js subprocess managed by `@escalated-dev/plugin-runtime` and communicate with Laravel over JSON-RPC 2.0 via stdio.
 
@@ -688,7 +688,7 @@ export default definePlugin({
 })
 ```
 
-## Documentation
+## 文档
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
@@ -698,14 +698,14 @@ export default definePlugin({
 - [Escalation Rules](docs/escalation-rules.md)
 - [Hosting Modes](docs/hosting-modes.md)
 
-## Testing
+## 测试
 
 ```bash
 composer install
 vendor/bin/pest
 ```
 
-## Also Available For
+## 其他框架版本
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package (you are here)
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -716,6 +716,6 @@ vendor/bin/pest
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## License
+## 许可证
 
 MIT


### PR DESCRIPTION
## Summary
- Add translated README files in `docs/translations/` for 13 languages: Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, and Chinese Simplified
- Add language selector bar at the top of the main README.md
- Each translated README includes the same language selector with the current language bolded and translated section headings

## Test plan
- [ ] Verify language selector links work in the main README
- [ ] Verify each translated file has correct language selector
- [ ] Verify English links back to ../../README.md from translation files