### PR TITLE
fix: address SSRF, validation, and audit logging vulnerabilities

### DIFF
--- a/routes/widget.php
+++ b/routes/widget.php
@@ -10,13 +10,13 @@ Route::middleware(['web', 'throttle:60,1'])
         Route::get('/config', [WidgetController::class, 'config'])->name('escalated.widget.config');
         Route::get('/articles', [WidgetController::class, 'searchArticles'])->name('escalated.widget.articles.search');
         Route::get('/articles/{slug}', [WidgetController::class, 'showArticle'])->name('escalated.widget.articles.show');
-        Route::post('/tickets', [WidgetController::class, 'createTicket'])->name('escalated.widget.tickets.store');
+        Route::post('/tickets', [WidgetController::class, 'createTicket'])->middleware('throttle:5,1')->name('escalated.widget.tickets.store');
         Route::get('/tickets/{reference}', [WidgetController::class, 'ticketStatus'])->name('escalated.widget.tickets.status');
 
         // Live Chat
         Route::get('/chat/availability', [WidgetChatController::class, 'availability'])->name('escalated.widget.chat.availability');
-        Route::post('/chat/start', [WidgetChatController::class, 'start'])->name('escalated.widget.chat.start');
-        Route::post('/chat/{sessionId}/message', [WidgetChatController::class, 'message'])->name('escalated.widget.chat.message');
+        Route::post('/chat/start', [WidgetChatController::class, 'start'])->middleware('throttle:5,1')->name('escalated.widget.chat.start');
+        Route::post('/chat/{sessionId}/message', [WidgetChatController::class, 'message'])->middleware('throttle:30,1')->name('escalated.widget.chat.message');
         Route::post('/chat/{sessionId}/typing', [WidgetChatController::class, 'typing'])->name('escalated.widget.chat.typing');
         Route::post('/chat/{sessionId}/end', [WidgetChatController::class, 'end'])->name('escalated.widget.chat.end');
         Route::post('/chat/{sessionId}/rate', [WidgetChatController::class, 'rate'])->name('escalated.widget.chat.rate');

--- a/src/Http/Controllers/Admin/ReportController.php
+++ b/src/Http/Controllers/Admin/ReportController.php
@@ -3,6 +3,7 @@
 namespace Escalated\Laravel\Http\Controllers\Admin;
 
 use Escalated\Laravel\Contracts\EscalatedUiRenderer;
+use Escalated\Laravel\Models\AuditLog;
 use Escalated\Laravel\Models\SatisfactionRating;
 use Escalated\Laravel\Models\Ticket;
 use Escalated\Laravel\Services\ReportExportService;
@@ -242,6 +243,14 @@ class ReportController extends Controller
         $filters = [
             'period' => $this->periodDays($request),
         ];
+
+        AuditLog::create([
+            'user_id' => $request->user()?->id,
+            'action' => 'report.exported',
+            'auditable_type' => Ticket::class,
+            'auditable_id' => 0,
+            'new_values' => ['type' => $type, 'format' => $format, 'period' => $filters['period']],
+        ]);
 
         if ($format === 'json') {
             return $this->exportService->exportToJson($type, $filters);

--- a/src/Http/Controllers/Admin/WorkflowController.php
+++ b/src/Http/Controllers/Admin/WorkflowController.php
@@ -3,6 +3,7 @@
 namespace Escalated\Laravel\Http\Controllers\Admin;
 
 use Escalated\Laravel\Contracts\EscalatedUiRenderer;
+use Escalated\Laravel\Models\AuditLog;
 use Escalated\Laravel\Models\Ticket;
 use Escalated\Laravel\Models\Workflow;
 use Escalated\Laravel\Services\WorkflowEngine;
@@ -40,11 +41,12 @@ class WorkflowController extends Controller
             'trigger_event' => 'required|string',
             'conditions' => 'required|array',
             'actions' => 'required|array|min:1',
+            'actions.*.type' => 'required|string|in:assign_agent,change_status,change_priority,add_tag,remove_tag,move_department,add_internal_note,send_notification,send_webhook,apply_macro,close_ticket,snooze_ticket,delay',
             'description' => 'nullable|string',
             'is_active' => 'boolean',
         ]);
 
-        Workflow::create([
+        $workflow = Workflow::create([
             'name' => $request->input('name'),
             'description' => $request->input('description'),
             'trigger_event' => $request->input('trigger_event'),
@@ -53,6 +55,14 @@ class WorkflowController extends Controller
             'is_active' => $request->boolean('is_active', true),
             'position' => (Workflow::max('position') ?? 0) + 1,
             'created_by' => $request->user()?->id,
+        ]);
+
+        AuditLog::create([
+            'user_id' => $request->user()?->id,
+            'action' => 'workflow.created',
+            'auditable_type' => $workflow->getMorphClass(),
+            'auditable_id' => $workflow->id,
+            'new_values' => ['name' => $workflow->name, 'trigger_event' => $workflow->trigger_event],
         ]);
 
         return redirect()->route('escalated.admin.workflows.index')
@@ -74,9 +84,12 @@ class WorkflowController extends Controller
             'trigger_event' => 'required|string',
             'conditions' => 'required|array',
             'actions' => 'required|array|min:1',
+            'actions.*.type' => 'required|string|in:assign_agent,change_status,change_priority,add_tag,remove_tag,move_department,add_internal_note,send_notification,send_webhook,apply_macro,close_ticket,snooze_ticket,delay',
             'description' => 'nullable|string',
             'is_active' => 'boolean',
         ]);
+
+        $oldValues = ['name' => $workflow->name, 'trigger_event' => $workflow->trigger_event];
 
         $workflow->update([
             'name' => $request->input('name'),
@@ -87,12 +100,29 @@ class WorkflowController extends Controller
             'is_active' => $request->boolean('is_active', true),
         ]);
 
+        AuditLog::create([
+            'user_id' => $request->user()?->id,
+            'action' => 'workflow.updated',
+            'auditable_type' => $workflow->getMorphClass(),
+            'auditable_id' => $workflow->id,
+            'old_values' => $oldValues,
+            'new_values' => ['name' => $workflow->name, 'trigger_event' => $workflow->trigger_event],
+        ]);
+
         return redirect()->route('escalated.admin.workflows.index')
             ->with('success', 'Workflow updated.');
     }
 
-    public function destroy(Workflow $workflow): RedirectResponse
+    public function destroy(Request $request, Workflow $workflow): RedirectResponse
     {
+        AuditLog::create([
+            'user_id' => $request->user()?->id,
+            'action' => 'workflow.deleted',
+            'auditable_type' => $workflow->getMorphClass(),
+            'auditable_id' => $workflow->id,
+            'old_values' => ['name' => $workflow->name, 'trigger_event' => $workflow->trigger_event],
+        ]);
+
         $workflow->delete();
 
         return redirect()->route('escalated.admin.workflows.index')

--- a/src/Services/WorkflowEngine.php
+++ b/src/Services/WorkflowEngine.php
@@ -179,7 +179,9 @@ class WorkflowEngine
                 : 0,
             'reply_count' => $ticket->replies()->where('is_internal_note', false)->count(),
             'is_first_reply' => $ticket->replies()->where('is_internal_note', false)->count() <= 1,
-            default => $ticket->{$field} ?? null,
+            default => in_array($field, ['subject', 'description', 'ticket_type', 'channel'])
+                ? ($ticket->{$field} ?? null)
+                : null,
         };
     }
 
@@ -213,7 +215,7 @@ class WorkflowEngine
             'less_than_or_equal' => is_numeric($actual) && is_numeric($expected) && $actual <= $expected,
             'is_empty' => empty($actual),
             'is_not_empty' => ! empty($actual),
-            'matches' => is_string($actual) && is_string($expected) && (bool) preg_match($expected, $actual),
+            'matches' => is_string($actual) && is_string($expected) && $this->safeRegexMatch($expected, $actual),
             default => false,
         };
     }
@@ -238,6 +240,25 @@ class WorkflowEngine
         }
 
         return false;
+    }
+
+    /**
+     * Safely execute a regex match with validation and ReDoS protection.
+     */
+    protected function safeRegexMatch(string $pattern, string $subject): bool
+    {
+        // Validate pattern compiles without errors
+        if (@preg_match($pattern, '') === false) {
+            return false;
+        }
+
+        // Set a PCRE backtrack limit to prevent ReDoS
+        $oldLimit = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '10000');
+        $result = @preg_match($pattern, $subject);
+        ini_set('pcre.backtrack_limit', $oldLimit);
+
+        return (bool) $result;
     }
 
     /**
@@ -413,7 +434,26 @@ class WorkflowEngine
 
         $url = $value['url'] ?? null;
 
-        if (! $url) {
+        if (! $url || ! filter_var($url, FILTER_VALIDATE_URL)) {
+            return;
+        }
+
+        // Block non-HTTP(S) schemes
+        if (! in_array(parse_url($url, PHP_URL_SCHEME), ['https', 'http'])) {
+            return;
+        }
+
+        // Block private/reserved IPs to prevent SSRF
+        $host = parse_url($url, PHP_URL_HOST);
+        $ip = gethostbyname($host);
+
+        if ($ip === $host) {
+            return; // DNS resolution failed
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            Log::warning('Escalated workflow: webhook blocked - resolves to private IP', ['url' => $url, 'ip' => $ip]);
+
             return;
         }
 


### PR DESCRIPTION
## Summary
- **CRITICAL**: Block SSRF in `WorkflowEngine::actionSendWebhook()` by validating URL scheme (http/https only) and rejecting URLs that resolve to private/reserved IPs
- **HIGH**: Prevent regex injection (ReDoS) in `compareValues()` `matches` operator via `safeRegexMatch()` with pattern validation and PCRE backtrack limit of 10,000
- **HIGH**: Add strict `in:` validation for `actions.*.type` in `WorkflowController` store/update to prevent arbitrary action type injection
- **MEDIUM**: Whitelist allowed fields (`subject`, `description`, `ticket_type`, `channel`) in `resolveFieldValue()` default case instead of open `$ticket->{$field}`
- **MEDIUM**: Apply granular rate limiting: ticket creation `5/min`, chat start `5/min`, chat message `30/min`
- **MEDIUM**: Add `AuditLog` entries for workflow create/update/delete and report exports

## Test plan
- [x] All 530 Pest tests pass (2481 assertions)
- [x] Pint formatting passes
- [x] Rate limiting test verified (no 429 false positives)