### PR TITLE
fix: include url in attachment serialization

### DIFF
--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -11,6 +11,8 @@ class Attachment extends Model
 {
     protected $guarded = ['id'];
 
+    protected $appends = ['url'];
+
     public function getTable(): string
     {
         return Escalated::table('attachments');
@@ -21,9 +23,14 @@ class Attachment extends Model
         return $this->morphTo();
     }
 
-    public function url(): string
+    public function getUrlAttribute(): string
     {
         return Storage::disk($this->disk)->url($this->path);
+    }
+
+    public function url(): string
+    {
+        return $this->url;
     }
 
     public function sizeForHumans(): string


### PR DESCRIPTION
## Summary
- Fixes escalated-dev/escalated#26 — attachment `url` was never included in serialized output
- Converted `url()` method to a `getUrlAttribute()` Eloquent accessor
- Added `url` to the model's `$appends` array so it's always present in JSON/Inertia responses
- Kept `url()` method as a backward-compatible wrapper

## Test plan
- [x] All 530 existing tests pass
- [ ] Verify attachments returned via Inertia now include `url` field
- [ ] Verify attachment download links work in agent, admin, and customer views