### PR TITLE
fix: include computed ticket fields in serialization

### DIFF
--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -29,6 +29,15 @@ class Ticket extends Model
 
     protected $guarded = ['id'];
 
+    protected $appends = [
+        'requester_name',
+        'requester_email',
+        'last_reply_at',
+        'last_reply_author',
+        'is_live_chat',
+        'is_snoozed',
+    ];
+
     protected $dispatchesEvents = [
         'updated' => Events\TicketUpdated::class,
     ];


### PR DESCRIPTION
## Summary
- Ticket model had 6 accessor methods that were never included in JSON/Inertia responses because `$appends` was missing
- Added `$appends` array with: `requester_name`, `requester_email`, `last_reply_at`, `last_reply_author`, `is_live_chat`, `is_snoozed`
- Same class of bug as the attachment `url` fix in #50

## Test plan
- [x] All 530 existing tests pass
- [ ] Verify ticket list and detail views display requester info, last reply, snooze state, and live chat status