### PR TITLE
fix: add chat, context panel, and activity fields to serialization

### DIFF
--- a/src/Http/Controllers/Admin/TicketController.php
+++ b/src/Http/Controllers/Admin/TicketController.php
@@ -59,7 +59,7 @@ class TicketController extends Controller
             'replies' => fn ($q) => $q->with('author', 'attachments')->latest(),
             'attachments', 'tags', 'department', 'requester', 'assignee',
             'slaPolicy', 'activities' => fn ($q) => $q->with('causer')->latest()->take(20),
-            'satisfactionRating', 'pinnedNotes.author',
+            'satisfactionRating', 'pinnedNotes.author', 'chatSession',
         ]);
 
         return $this->renderer->render('Escalated/Admin/Tickets/Show', [

--- a/src/Http/Controllers/Agent/TicketController.php
+++ b/src/Http/Controllers/Agent/TicketController.php
@@ -55,7 +55,7 @@ class TicketController extends Controller
             'replies' => fn ($q) => $q->with('author', 'attachments')->latest(),
             'attachments', 'tags', 'department', 'requester', 'assignee',
             'slaPolicy', 'activities' => fn ($q) => $q->with('causer')->latest()->take(20),
-            'satisfactionRating', 'pinnedNotes.author',
+            'satisfactionRating', 'pinnedNotes.author', 'chatSession',
         ]);
 
         return $this->renderer->render('Escalated/Agent/TicketShow', [

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -36,6 +36,11 @@ class Ticket extends Model
         'last_reply_author',
         'is_live_chat',
         'is_snoozed',
+        'chat_session_id',
+        'chat_started_at',
+        'chat_messages',
+        'requester_ticket_count',
+        'related_tickets',
     ];
 
     protected $dispatchesEvents = [
@@ -329,6 +334,58 @@ class Ticket extends Model
     public function getIsSnoozedAttribute(): bool
     {
         return $this->snoozed_until !== null && $this->snoozed_until->isFuture();
+    }
+
+    public function getChatSessionIdAttribute(): ?int
+    {
+        return $this->chatSession?->id;
+    }
+
+    public function getChatStartedAtAttribute(): ?string
+    {
+        return $this->chatSession?->started_at?->toIso8601String();
+    }
+
+    public function getChatMessagesAttribute(): array
+    {
+        if (! $this->is_live_chat) {
+            return [];
+        }
+
+        return Reply::where('ticket_id', $this->id)
+            ->with('author')
+            ->oldest()
+            ->get()
+            ->map(fn ($r) => [
+                'id' => $r->id,
+                'body' => $r->body,
+                'is_internal_note' => $r->is_internal_note,
+                'is_agent' => $r->author_type !== null && $r->author_type !== $this->requester_type,
+                'author' => $r->author ? ['id' => $r->author->getKey(), 'name' => $r->author->name] : null,
+                'created_at' => $r->created_at?->toIso8601String(),
+            ])
+            ->toArray();
+    }
+
+    public function getRequesterTicketCountAttribute(): int
+    {
+        if ($this->isGuest()) {
+            return self::where('guest_email', $this->guest_email)->count();
+        }
+
+        return self::where('requester_type', $this->requester_type)
+            ->where('requester_id', $this->requester_id)
+            ->count();
+    }
+
+    public function getRelatedTicketsAttribute(): array
+    {
+        $parentIds = $this->linksAsChild()->pluck('parent_ticket_id');
+        $childIds = $this->linksAsParent()->pluck('child_ticket_id');
+
+        return self::whereIn('id', $parentIds->merge($childIds))
+            ->get(['id', 'reference', 'subject', 'status'])
+            ->toArray();
     }
 
     // Helpers

--- a/src/Models/TicketActivity.php
+++ b/src/Models/TicketActivity.php
@@ -12,6 +12,8 @@ class TicketActivity extends Model
 {
     protected $guarded = ['id'];
 
+    protected $appends = ['created_at_human'];
+
     public $timestamps = true;
 
     const UPDATED_AT = null;
@@ -37,5 +39,10 @@ class TicketActivity extends Model
     public function causer(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    public function getCreatedAtHumanAttribute(): string
+    {
+        return $this->created_at?->diffForHumans() ?? '';
     }
 }


### PR DESCRIPTION
## Summary
- Add `chat_session_id`, `chat_started_at`, `chat_messages` accessors for live chat WebSocket subscription and initial message load
- Add `requester_ticket_count` and `related_tickets` accessors for the context panel
- Add `created_at_human` accessor to TicketActivity for the activity timeline
- Eager-load `chatSession` in agent and admin ticket controllers

## Test plan
- [x] All 530 existing tests pass
- [ ] Verify live chat mode shows chat messages and connects to WebSocket
- [ ] Verify context panel shows requester ticket count and related tickets
- [ ] Verify activity timeline shows human-readable timestamps