### PR TITLE
fix: move expensive computed fields from $appends to detail-only

### DIFF
--- a/src/Http/Controllers/Admin/TicketController.php
+++ b/src/Http/Controllers/Admin/TicketController.php
@@ -60,7 +60,10 @@ class TicketController extends Controller
             'attachments', 'tags', 'department', 'requester', 'assignee',
             'slaPolicy', 'activities' => fn ($q) => $q->with('causer')->latest()->take(20),
             'satisfactionRating', 'pinnedNotes.author', 'chatSession',
+            'linksAsParent.childTicket', 'linksAsChild.parentTicket',
         ]);
+
+        $ticket->append(['chat_session_id', 'chat_started_at', 'chat_messages', 'requester_ticket_count', 'related_tickets']);
 
         return $this->renderer->render('Escalated/Admin/Tickets/Show', [
             'ticket' => $ticket,

--- a/src/Http/Controllers/Agent/TicketController.php
+++ b/src/Http/Controllers/Agent/TicketController.php
@@ -56,7 +56,10 @@ class TicketController extends Controller
             'attachments', 'tags', 'department', 'requester', 'assignee',
             'slaPolicy', 'activities' => fn ($q) => $q->with('causer')->latest()->take(20),
             'satisfactionRating', 'pinnedNotes.author', 'chatSession',
+            'linksAsParent.childTicket', 'linksAsChild.parentTicket',
         ]);
+
+        $ticket->append(['chat_session_id', 'chat_started_at', 'chat_messages', 'requester_ticket_count', 'related_tickets']);
 
         return $this->renderer->render('Escalated/Agent/TicketShow', [
             'ticket' => $ticket,

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -36,11 +36,6 @@ class Ticket extends Model
         'last_reply_author',
         'is_live_chat',
         'is_snoozed',
-        'chat_session_id',
-        'chat_started_at',
-        'chat_messages',
-        'requester_ticket_count',
-        'related_tickets',
     ];
 
     protected $dispatchesEvents = [
@@ -352,25 +347,34 @@ class Ticket extends Model
             return [];
         }
 
-        return Reply::where('ticket_id', $this->id)
-            ->with('author')
-            ->oldest()
-            ->get()
+        $replies = $this->relationLoaded('replies')
+            ? $this->replies->sortBy('created_at')
+            : $this->replies()->with('author')->oldest()->get();
+
+        return $replies
+            ->reject(fn ($r) => $r->is_internal_note)
             ->map(fn ($r) => [
                 'id' => $r->id,
                 'body' => $r->body,
-                'is_internal_note' => $r->is_internal_note,
+                'is_internal_note' => false,
                 'is_agent' => $r->author_type !== null && $r->author_type !== $this->requester_type,
                 'author' => $r->author ? ['id' => $r->author->getKey(), 'name' => $r->author->name] : null,
                 'created_at' => $r->created_at?->toIso8601String(),
             ])
+            ->values()
             ->toArray();
     }
 
     public function getRequesterTicketCountAttribute(): int
     {
         if ($this->isGuest()) {
-            return self::where('guest_email', $this->guest_email)->count();
+            return $this->guest_email
+                ? self::where('guest_email', $this->guest_email)->count()
+                : 1;
+        }
+
+        if (! $this->requester_type || ! $this->requester_id) {
+            return 1;
         }
 
         return self::where('requester_type', $this->requester_type)


### PR DESCRIPTION
## Summary (Code Review Follow-up)

Addresses critical issues found during review of the serialization fixes:

### Performance (CRITICAL)
- Removed `chat_session_id`, `chat_started_at`, `chat_messages`, `requester_ticket_count`, `related_tickets` from global `$appends`
- These were causing ~75+ extra DB queries per ticket list page (N+1 on chatSession, COUNT per ticket, 3 queries per ticket for related_tickets)
- Now selectively appended only in agent/admin `show()` methods via `$ticket->append([...])`

### Security (CRITICAL)
- `chat_messages` now filters out internal notes (`is_internal_note`) to prevent data leakage to customer/guest views
- `requester_ticket_count` and `related_tickets` are no longer exposed to customer/guest views

### Bug fixes
- `getChatMessagesAttribute` now uses the already-loaded replies relationship instead of running a duplicate query
- `getRequesterTicketCountAttribute` guards against null `guest_email` (previously counted all null-email tickets)
- Eager-loads `linksAsParent.childTicket` and `linksAsChild.parentTicket` for related_tickets

## Test plan
- [x] All 530 existing tests pass
- [ ] Verify ticket list page loads without excessive queries
- [ ] Verify agent/admin detail pages still show chat, related tickets, requester count
- [ ] Verify customer/guest views do NOT show internal notes or agent-only data