### PR TITLE
fix: add missing workflow and workflow log computed fields

### DIFF
--- a/src/Http/Controllers/Admin/WorkflowController.php
+++ b/src/Http/Controllers/Admin/WorkflowController.php
@@ -156,7 +156,7 @@ class WorkflowController extends Controller
     public function logs(Workflow $workflow): mixed
     {
         $logs = $workflow->workflowLogs()
-            ->with('ticket')
+            ->with('workflow', 'ticket')
             ->latest()
             ->paginate(25);
 

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -11,6 +11,8 @@ class Workflow extends Model
 {
     protected $guarded = ['id'];
 
+    protected $appends = ['trigger'];
+
     public function getTable(): string
     {
         return Escalated::table('workflows');
@@ -41,6 +43,11 @@ class Workflow extends Model
     public function delayedActions(): HasMany
     {
         return $this->hasMany(DelayedAction::class, 'workflow_id');
+    }
+
+    public function getTriggerAttribute(): ?string
+    {
+        return $this->trigger_event;
     }
 
     public function scopeActive($query)

--- a/src/Models/WorkflowLog.php
+++ b/src/Models/WorkflowLog.php
@@ -10,6 +10,16 @@ class WorkflowLog extends Model
 {
     protected $guarded = ['id'];
 
+    protected $appends = [
+        'workflow_name',
+        'ticket_reference',
+        'event',
+        'matched',
+        'duration_ms',
+        'status',
+        'action_details',
+    ];
+
     public function getTable(): string
     {
         return Escalated::table('workflow_logs');
@@ -33,5 +43,44 @@ class WorkflowLog extends Model
     public function ticket(): BelongsTo
     {
         return $this->belongsTo(Ticket::class, 'ticket_id');
+    }
+
+    public function getWorkflowNameAttribute(): ?string
+    {
+        return $this->workflow?->name;
+    }
+
+    public function getTicketReferenceAttribute(): ?string
+    {
+        return $this->ticket?->reference;
+    }
+
+    public function getEventAttribute(): ?string
+    {
+        return $this->trigger_event;
+    }
+
+    public function getMatchedAttribute(): bool
+    {
+        return (bool) $this->conditions_matched;
+    }
+
+    public function getDurationMsAttribute(): ?int
+    {
+        if (! $this->started_at || ! $this->completed_at) {
+            return null;
+        }
+
+        return (int) $this->started_at->diffInMilliseconds($this->completed_at);
+    }
+
+    public function getStatusAttribute(): string
+    {
+        return $this->error ? 'failed' : 'success';
+    }
+
+    public function getActionDetailsAttribute(): array
+    {
+        return is_array($this->actions_executed) ? $this->actions_executed : [];
     }
 }


### PR DESCRIPTION
## Summary
- **Workflow model**: Added `trigger` accessor aliasing `trigger_event` column — frontend accesses `workflow.trigger` but DB stores `trigger_event`
- **WorkflowLog model**: Added 7 computed fields via `$appends`:
  - `workflow_name` — from eager-loaded workflow relationship
  - `ticket_reference` — from eager-loaded ticket relationship  
  - `event` — alias for `trigger_event`
  - `matched` — boolean alias for `conditions_matched`
  - `duration_ms` — computed from `started_at`/`completed_at`
  - `status` — 'failed' if error present, otherwise 'success'
  - `action_details` — raw actions array for expanded detail view
- Eager-loads `workflow` relationship in logs controller

## Test plan
- [x] All 530 existing tests pass
- [ ] Verify workflow list shows trigger badges correctly
- [ ] Verify workflow logs table shows all columns with correct data
- [ ] Verify expanded log detail shows action-by-action execution