### PR TITLE
fix: register Database\Seeders namespace in production autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Escalated\\Laravel\\": "src/"
+            "Escalated\\Laravel\\": "src/",
+            "Escalated\\Laravel\\Database\\Seeders\\": "database/seeders/"
         },
         "files": [
             "src/Support/helpers.php"


### PR DESCRIPTION
## Summary

- `database/seeders/PermissionSeeder.php` declares namespace `Escalated\Laravel\Database\Seeders`, but `composer.json` only mapped `Escalated\Laravel\ -> src/` in production autoload (the `Database\Factories\` mapping was scoped to `autoload-dev`).
- When an end-user runs `php artisan escalated:install`, the install command calls `db:seed --class=PermissionSeeder::class`, but Composer's runtime autoloader can't locate the class, producing `BindingResolutionException: Target class [Escalated\Laravel\Database\Seeders\PermissionSeeder] does not exist`.
- Fix: add a PSR-4 entry mapping `Escalated\Laravel\Database\Seeders\ -> database/seeders/` to the production `autoload` block.

Fixes #55

## Test plan

- [ ] `composer dump-autoload` and confirm `Escalated\Laravel\Database\Seeders\` appears in `vendor/composer/autoload_psr4.php`.
- [ ] In a fresh Laravel app, `composer require escalated-dev/escalated-laravel` then `php artisan escalated:install` completes without the BindingResolutionException and `permissions` / `roles` tables are populated.
- [ ] Existing test suite still passes.