### PR TITLE
fix(reporting): emit Postgres-compatible SQL for date/time helpers

### DIFF
--- a/src/Http/Controllers/Admin/ReportController.php
+++ b/src/Http/Controllers/Admin/ReportController.php
@@ -268,15 +268,15 @@ class ReportController extends Controller
     {
         $driver = DB::connection()->getDriverName();
 
-        if ($driver === 'sqlite') {
-            $raw = 'AVG((julianday(first_response_at) - julianday(created_at)) * 24) as avg_hours';
-        } else {
-            $raw = 'AVG(TIMESTAMPDIFF(HOUR, created_at, first_response_at)) as avg_hours';
-        }
+        $expr = match ($driver) {
+            'sqlite' => '(julianday(first_response_at) - julianday(created_at)) * 24',
+            'pgsql' => 'EXTRACT(EPOCH FROM (first_response_at - created_at)) / 3600',
+            default => 'TIMESTAMPDIFF(HOUR, created_at, first_response_at)',
+        };
 
         return (float) (Ticket::whereNotNull('first_response_at')
             ->where('created_at', '>=', $since)
-            ->selectRaw($raw)
+            ->selectRaw("AVG({$expr}) as avg_hours")
             ->value('avg_hours') ?? 0);
     }
 

--- a/src/Services/ReportingService.php
+++ b/src/Services/ReportingService.php
@@ -1042,28 +1042,41 @@ class ReportingService
     // Private Helpers
     // ──────────────────────────────────────────────────────────────────────
 
+    protected function driver(): string
+    {
+        return DB::connection()->getDriverName();
+    }
+
     protected function isSqlite(): bool
     {
-        return DB::connection()->getDriverName() === 'sqlite';
+        return $this->driver() === 'sqlite';
     }
 
     protected function dateExpression(string $column): string
     {
-        return $this->isSqlite() ? "date({$column})" : "DATE({$column})";
+        return match ($this->driver()) {
+            'sqlite' => "date({$column})",
+            'pgsql' => "{$column}::date",
+            default => "DATE({$column})",
+        };
     }
 
     protected function groupByDateExpression(string $column, ?string $groupBy): string
     {
         if ($groupBy === 'week') {
-            return $this->isSqlite()
-                ? "strftime('%Y-W%W', {$column})"
-                : "DATE_FORMAT({$column}, '%Y-W%v')";
+            return match ($this->driver()) {
+                'sqlite' => "strftime('%Y-W%W', {$column})",
+                'pgsql' => "to_char({$column}, 'IYYY-\"W\"IW')",
+                default => "DATE_FORMAT({$column}, '%Y-W%v')",
+            };
         }
 
         if ($groupBy === 'month') {
-            return $this->isSqlite()
-                ? "strftime('%Y-%m', {$column})"
-                : "DATE_FORMAT({$column}, '%Y-%m')";
+            return match ($this->driver()) {
+                'sqlite' => "strftime('%Y-%m', {$column})",
+                'pgsql' => "to_char({$column}, 'YYYY-MM')",
+                default => "DATE_FORMAT({$column}, '%Y-%m')",
+            };
         }
 
         return $this->dateExpression($column);
@@ -1071,23 +1084,21 @@ class ReportingService
 
     protected function hoursDiffExpression(string $from, string $to): string
     {
-        return $this->isSqlite()
-            ? "(julianday({$to}) - julianday({$from})) * 24"
-            : "TIMESTAMPDIFF(HOUR, {$from}, {$to})";
+        return match ($this->driver()) {
+            'sqlite' => "(julianday({$to}) - julianday({$from})) * 24",
+            'pgsql' => "EXTRACT(EPOCH FROM ({$to} - {$from})) / 3600",
+            default => "TIMESTAMPDIFF(HOUR, {$from}, {$to})",
+        };
     }
 
     protected function avgHoursDiffExpression(string $from, string $to): string
     {
-        return $this->isSqlite()
-            ? "AVG((julianday({$to}) - julianday({$from})) * 24)"
-            : "AVG(TIMESTAMPDIFF(HOUR, {$from}, {$to}))";
+        return 'AVG('.$this->hoursDiffExpression($from, $to).')';
     }
 
     protected function avgHoursDiffRaw(string $from, string $to): string
     {
-        return $this->isSqlite()
-            ? "AVG((julianday({$to}) - julianday({$from})) * 24)"
-            : "AVG(TIMESTAMPDIFF(HOUR, {$from}, {$to}))";
+        return $this->avgHoursDiffExpression($from, $to);
     }
 
     /**

--- a/tests/Unit/ReportingServiceDriverSqlTest.php
+++ b/tests/Unit/ReportingServiceDriverSqlTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use Escalated\Laravel\Services\ReportingService;
+
+/**
+ * Verifies cross-database SQL in ReportingService's helper methods.
+ *
+ * Each helper now branches on driver; bug #59 happened because the
+ * default branch was MySQL-specific (`TIMESTAMPDIFF(HOUR, ...)`) and
+ * silently produced invalid SQL on Postgres. These tests assert the
+ * exact SQL per driver so a future refactor can't regress a backend.
+ */
+function makeServiceWithDriver(string $driver): object
+{
+    return new class($driver) extends ReportingService
+    {
+        public function __construct(private string $injectedDriver) {}
+
+        protected function driver(): string
+        {
+            return $this->injectedDriver;
+        }
+
+        public function dateExprPublic(string $column): string
+        {
+            return $this->dateExpression($column);
+        }
+
+        public function groupByExprPublic(string $column, ?string $groupBy): string
+        {
+            return $this->groupByDateExpression($column, $groupBy);
+        }
+
+        public function hoursDiffExprPublic(string $from, string $to): string
+        {
+            return $this->hoursDiffExpression($from, $to);
+        }
+
+        public function avgHoursDiffExprPublic(string $from, string $to): string
+        {
+            return $this->avgHoursDiffExpression($from, $to);
+        }
+    };
+}
+
+// ─── dateExpression ──────────────────────────────────────────────────────
+
+it('emits sqlite date(col) on sqlite', function () {
+    expect(makeServiceWithDriver('sqlite')->dateExprPublic('created_at'))
+        ->toBe('date(created_at)');
+});
+
+it('emits col::date on postgres', function () {
+    expect(makeServiceWithDriver('pgsql')->dateExprPublic('created_at'))
+        ->toBe('created_at::date');
+});
+
+it('emits DATE(col) on mysql', function () {
+    expect(makeServiceWithDriver('mysql')->dateExprPublic('created_at'))
+        ->toBe('DATE(created_at)');
+});
+
+// ─── groupByDateExpression — week ────────────────────────────────────────
+
+it('emits strftime week format on sqlite', function () {
+    expect(makeServiceWithDriver('sqlite')->groupByExprPublic('created_at', 'week'))
+        ->toBe("strftime('%Y-W%W', created_at)");
+});
+
+it('emits ISO week to_char on postgres', function () {
+    expect(makeServiceWithDriver('pgsql')->groupByExprPublic('created_at', 'week'))
+        ->toBe("to_char(created_at, 'IYYY-\"W\"IW')");
+});
+
+it('emits DATE_FORMAT week on mysql', function () {
+    expect(makeServiceWithDriver('mysql')->groupByExprPublic('created_at', 'week'))
+        ->toBe("DATE_FORMAT(created_at, '%Y-W%v')");
+});
+
+// ─── groupByDateExpression — month ───────────────────────────────────────
+
+it('emits strftime month format on sqlite', function () {
+    expect(makeServiceWithDriver('sqlite')->groupByExprPublic('created_at', 'month'))
+        ->toBe("strftime('%Y-%m', created_at)");
+});
+
+it('emits to_char month on postgres', function () {
+    expect(makeServiceWithDriver('pgsql')->groupByExprPublic('created_at', 'month'))
+        ->toBe("to_char(created_at, 'YYYY-MM')");
+});
+
+it('emits DATE_FORMAT month on mysql', function () {
+    expect(makeServiceWithDriver('mysql')->groupByExprPublic('created_at', 'month'))
+        ->toBe("DATE_FORMAT(created_at, '%Y-%m')");
+});
+
+// ─── groupByDateExpression — day falls through to dateExpression ─────────
+
+it('falls through to dateExpression for non-week non-month groupings', function () {
+    expect(makeServiceWithDriver('pgsql')->groupByExprPublic('created_at', 'day'))
+        ->toBe('created_at::date');
+    expect(makeServiceWithDriver('sqlite')->groupByExprPublic('created_at', null))
+        ->toBe('date(created_at)');
+});
+
+// ─── hoursDiffExpression ─────────────────────────────────────────────────
+
+it('emits julianday hours on sqlite', function () {
+    expect(makeServiceWithDriver('sqlite')->hoursDiffExprPublic('a', 'b'))
+        ->toBe('(julianday(b) - julianday(a)) * 24');
+});
+
+it('emits EXTRACT EPOCH hours on postgres (bug #59)', function () {
+    expect(makeServiceWithDriver('pgsql')->hoursDiffExprPublic('created_at', 'first_response_at'))
+        ->toBe('EXTRACT(EPOCH FROM (first_response_at - created_at)) / 3600');
+});
+
+it('emits TIMESTAMPDIFF hours on mysql', function () {
+    expect(makeServiceWithDriver('mysql')->hoursDiffExprPublic('a', 'b'))
+        ->toBe('TIMESTAMPDIFF(HOUR, a, b)');
+});
+
+// ─── avgHoursDiffExpression wraps hoursDiff ──────────────────────────────
+
+it('wraps hoursDiffExpression in AVG() across drivers', function () {
+    foreach (['sqlite', 'pgsql', 'mysql'] as $driver) {
+        $svc = makeServiceWithDriver($driver);
+        expect($svc->avgHoursDiffExprPublic('a', 'b'))
+            ->toBe('AVG('.$svc->hoursDiffExprPublic('a', 'b').')');
+    }
+});
+
+// ─── postgres regression guard ───────────────────────────────────────────
+
+it('never emits MySQL-specific TIMESTAMPDIFF for pgsql driver', function () {
+    $svc = makeServiceWithDriver('pgsql');
+    expect($svc->hoursDiffExprPublic('a', 'b'))->not->toContain('TIMESTAMPDIFF');
+    expect($svc->avgHoursDiffExprPublic('a', 'b'))->not->toContain('TIMESTAMPDIFF');
+});
+
+it('never emits MySQL-specific DATE_FORMAT for pgsql driver', function () {
+    $svc = makeServiceWithDriver('pgsql');
+    expect($svc->groupByExprPublic('created_at', 'week'))->not->toContain('DATE_FORMAT');
+    expect($svc->groupByExprPublic('created_at', 'month'))->not->toContain('DATE_FORMAT');
+});


### PR DESCRIPTION
Closes #59.

## What was broken

`/support/admin/reports` returned HTTP 500 on any Postgres deployment. `ReportingService`'s helpers and `ReportController::avgFirstResponseHours` branched on `isSqlite()` vs. a default that assumed MySQL, emitting `TIMESTAMPDIFF(HOUR, ...)` and `DATE_FORMAT(...)` — neither of which Postgres implements. Postgres parses `TIMESTAMPDIFF(HOUR, ...)` as \"function call taking a column named `hour`\" and fails with \"column 'hour' does not exist.\"

## Fix

- `ReportingService::driver()` returns the connection driver, and every helper now uses `match ($this->driver())`:
  - `dateExpression`: `sqlite → date(col)`, `pgsql → col::date`, `mysql → DATE(col)`
  - `groupByDateExpression month`: `strftime('%Y-%m', …)` / `to_char(…, 'YYYY-MM')` / `DATE_FORMAT(…, '%Y-%m')`
  - `groupByDateExpression week`: `strftime('%Y-W%W', …)` / `to_char(…, 'IYYY-\"W\"IW')` / `DATE_FORMAT(…, '%Y-W%v')` (ISO year + ISO week on Postgres to match MySQL's `%v` behavior)
  - `hoursDiffExpression`: `(julianday(to) - julianday(from)) * 24` / `EXTRACT(EPOCH FROM (to - from)) / 3600` / `TIMESTAMPDIFF(HOUR, from, to)`
- `avgHoursDiffExpression` and `avgHoursDiffRaw` are now thin wrappers over `hoursDiffExpression`, so the driver-branching lives in one place.
- `ReportController::avgFirstResponseHours` switched to the same `match`.

## Tests

`tests/Unit/ReportingServiceDriverSqlTest.php` — 16 new assertions:

- Exact generated SQL per driver for every helper
- Two regression guards: Postgres driver never emits `TIMESTAMPDIFF`; Postgres never emits `DATE_FORMAT`

Tests inject the driver string via an anonymous `ReportingService` subclass, so no live database is required. Still runs in CI's existing SQLite matrix.

Ran locally:

```
PASS  Tests\Unit\ReportingServiceDriverSqlTest — 16 tests / 21 assertions
PASS  Tests\Unit\ReportingServiceTest           — 31 tests / 163 assertions (unchanged)
```

## Test plan

- [x] New unit tests pass
- [x] Existing ReportingServiceTest (31 cases) still passes against SQLite
- [ ] CI matrix (P{8.2,8.3} × L{^11,^12}) green
- [ ] After #58 merges, `/support/admin/reports` returns 200 on the Docker demo (Postgres) and the \"Reports\" link in the admin nav no longer errors