### PR TITLE
fix(install): skip publishing migrations when already published

### DIFF
--- a/resources/lang/ar/commands.php
+++ b/resources/lang/ar/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'جارٍ تثبيت Escalated...',
         'publishing_config' => 'نشر الإعدادات',
         'publishing_migrations' => 'نشر عمليات الترحيل',
+        'migrations_already_published' => ':count ملف ترحيل من Escalated منشور بالفعل؛ تم التخطي. أعد التشغيل مع --force لاستبدالها.',
         'publishing_views' => 'نشر قوالب البريد الإلكتروني',
         'installing_npm' => 'تثبيت حزمة npm',
         'npm_manual' => 'تعذّر تثبيت حزمة npm تلقائيًا. قم بتشغيل الأمر يدويًا:',

--- a/resources/lang/de/commands.php
+++ b/resources/lang/de/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Escalated wird installiert...',
         'publishing_config' => 'Konfiguration wird veröffentlicht',
         'publishing_migrations' => 'Migrationen werden veröffentlicht',
+        'migrations_already_published' => ':count Escalated-Migration(en) bereits veröffentlicht; übersprungen. Mit --force neu veröffentlichen.',
         'publishing_views' => 'E-Mail-Ansichten werden veröffentlicht',
         'installing_npm' => 'npm-Paket wird installiert',
         'npm_manual' => 'npm-Paket konnte nicht automatisch installiert werden. Führen Sie manuell aus:',

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Installing Escalated...',
         'publishing_config' => 'Publishing configuration',
         'publishing_migrations' => 'Publishing migrations',
+        'migrations_already_published' => ':count Escalated migration(s) already published; skipping. Re-run with --force to replace them.',
         'publishing_views' => 'Publishing email views',
         'installing_npm' => 'Installing npm package',
         'npm_manual' => 'Could not install npm package automatically. Run manually:',

--- a/resources/lang/es/commands.php
+++ b/resources/lang/es/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Instalando Escalated...',
         'publishing_config' => 'Publicando configuración',
         'publishing_migrations' => 'Publicando migraciones',
+        'migrations_already_published' => ':count migración(es) de Escalated ya publicada(s); omitiendo. Vuelve a ejecutar con --force para reemplazarlas.',
         'publishing_views' => 'Publicando vistas de correo',
         'installing_npm' => 'Instalando paquete npm',
         'npm_manual' => 'No se pudo instalar el paquete npm automáticamente. Ejecute manualmente:',

--- a/resources/lang/fr/commands.php
+++ b/resources/lang/fr/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Installation d\'Escalated...',
         'publishing_config' => 'Publication de la configuration',
         'publishing_migrations' => 'Publication des migrations',
+        'migrations_already_published' => ':count migration(s) Escalated déjà publiée(s) ; ignoré. Relancez avec --force pour les remplacer.',
         'publishing_views' => 'Publication des vues e-mail',
         'installing_npm' => 'Installation du paquet npm',
         'npm_manual' => 'Impossible d\'installer le paquet npm automatiquement. Exécutez manuellement :',

--- a/resources/lang/it/commands.php
+++ b/resources/lang/it/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Installazione di Escalated...',
         'publishing_config' => 'Pubblicazione della configurazione',
         'publishing_migrations' => 'Pubblicazione delle migrazioni',
+        'migrations_already_published' => ':count migrazione(i) di Escalated già pubblicata(e); saltata. Esegui di nuovo con --force per sostituirle.',
         'publishing_views' => 'Pubblicazione delle viste email',
         'installing_npm' => 'Installazione del pacchetto npm',
         'npm_manual' => 'Impossibile installare automaticamente il pacchetto npm. Esegui manualmente:',

--- a/resources/lang/ja/commands.php
+++ b/resources/lang/ja/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Escalated をインストールしています...',
         'publishing_config' => '設定ファイルを公開しています',
         'publishing_migrations' => 'マイグレーションを公開しています',
+        'migrations_already_published' => 'Escalated のマイグレーション :count 件は既に公開済みのためスキップしました。--force を付けて再実行すると置き換えます。',
         'publishing_views' => 'メールビューを公開しています',
         'installing_npm' => 'npm パッケージをインストールしています',
         'npm_manual' => 'npm パッケージを自動でインストールできませんでした。手動で実行してください:',

--- a/resources/lang/ko/commands.php
+++ b/resources/lang/ko/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Escalated 설치 중...',
         'publishing_config' => '설정 파일 게시 중',
         'publishing_migrations' => '마이그레이션 게시 중',
+        'migrations_already_published' => 'Escalated 마이그레이션 :count개가 이미 게시되어 건너뜁니다. --force 옵션으로 다시 실행하면 교체됩니다.',
         'publishing_views' => '이메일 뷰 게시 중',
         'installing_npm' => 'npm 패키지 설치 중',
         'npm_manual' => 'npm 패키지를 자동으로 설치할 수 없습니다. 수동으로 실행하세요:',

--- a/resources/lang/nl/commands.php
+++ b/resources/lang/nl/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Escalated wordt geïnstalleerd...',
         'publishing_config' => 'Configuratie publiceren',
         'publishing_migrations' => 'Migraties publiceren',
+        'migrations_already_published' => ':count Escalated-migratie(s) al gepubliceerd; overgeslagen. Voer opnieuw uit met --force om ze te vervangen.',
         'publishing_views' => 'E-mailweergaven publiceren',
         'installing_npm' => 'npm-pakket installeren',
         'npm_manual' => 'Kan het npm-pakket niet automatisch installeren. Voer handmatig uit:',

--- a/resources/lang/pl/commands.php
+++ b/resources/lang/pl/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Instalowanie Escalated...',
         'publishing_config' => 'Publikowanie konfiguracji',
         'publishing_migrations' => 'Publikowanie migracji',
+        'migrations_already_published' => 'Opublikowano już :count migracj(ę|e) pakietu Escalated; pomijam. Uruchom ponownie z --force, aby je zastąpić.',
         'publishing_views' => 'Publikowanie widoków e-mail',
         'installing_npm' => 'Instalowanie pakietu npm',
         'npm_manual' => 'Nie udało się automatycznie zainstalować pakietu npm. Uruchom ręcznie:',

--- a/resources/lang/pt_BR/commands.php
+++ b/resources/lang/pt_BR/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Instalando o Escalated...',
         'publishing_config' => 'Publicando configuração',
         'publishing_migrations' => 'Publicando migrações',
+        'migrations_already_published' => ':count migração(ões) do Escalated já publicada(s); ignorando. Execute novamente com --force para substituí-las.',
         'publishing_views' => 'Publicando visualizações de e-mail',
         'installing_npm' => 'Instalando pacote npm',
         'npm_manual' => 'Não foi possível instalar o pacote npm automaticamente. Execute manualmente:',

--- a/resources/lang/ru/commands.php
+++ b/resources/lang/ru/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Установка Escalated...',
         'publishing_config' => 'Публикация конфигурации',
         'publishing_migrations' => 'Публикация миграций',
+        'migrations_already_published' => 'Миграции Escalated уже опубликованы (:count); пропущено. Запустите снова с --force, чтобы заменить их.',
         'publishing_views' => 'Публикация шаблонов электронной почты',
         'installing_npm' => 'Установка npm-пакета',
         'npm_manual' => 'Не удалось автоматически установить npm-пакет. Выполните вручную:',

--- a/resources/lang/tr/commands.php
+++ b/resources/lang/tr/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => 'Escalated kuruluyor...',
         'publishing_config' => 'Yapılandırma yayınlanıyor',
         'publishing_migrations' => 'Geçişler yayınlanıyor',
+        'migrations_already_published' => ':count Escalated geçişi zaten yayımlanmış; atlanıyor. Değiştirmek için --force ile yeniden çalıştırın.',
         'publishing_views' => 'E-posta görünümleri yayınlanıyor',
         'installing_npm' => 'npm paketi kuruluyor',
         'npm_manual' => 'npm paketi otomatik olarak kurulamadı. Manuel olarak çalıştırın:',

--- a/resources/lang/zh_CN/commands.php
+++ b/resources/lang/zh_CN/commands.php
@@ -6,6 +6,7 @@ return [
         'installing' => '正在安装 Escalated...',
         'publishing_config' => '正在发布配置文件',
         'publishing_migrations' => '正在发布数据库迁移',
+        'migrations_already_published' => '已发布 :count 个 Escalated 迁移文件；已跳过。使用 --force 重新运行可替换它们。',
         'publishing_views' => '正在发布邮件视图',
         'installing_npm' => '正在安装 npm 包',
         'npm_manual' => '无法自动安装 npm 包。请手动运行：',

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -61,11 +61,48 @@ class InstallCommand extends Command
     protected function publishMigrations(bool $force): void
     {
         $this->components->task(__('escalated::commands.install.publishing_migrations'), function () use ($force) {
+            $existing = $this->existingPublishedMigrations();
+
+            if (! empty($existing) && ! $force) {
+                $this->components->info(__(
+                    'escalated::commands.install.migrations_already_published',
+                    ['count' => count($existing)]
+                ));
+
+                return;
+            }
+
+            if (! empty($existing) && $force) {
+                foreach ($existing as $path) {
+                    @unlink($path);
+                }
+            }
+
             $this->callSilently('vendor:publish', [
                 '--tag' => 'escalated-migrations',
                 '--force' => $force,
             ]);
         });
+    }
+
+    /**
+     * Returns absolute paths of already-published Escalated migration files in
+     * the host app's database/migrations directory. A migration counts as
+     * "published by Escalated" if its filename ends in _create_escalated_*_table.php.
+     *
+     * @return array<int, string>
+     */
+    protected function existingPublishedMigrations(): array
+    {
+        $migrationsDir = database_path('migrations');
+
+        if (! is_dir($migrationsDir)) {
+            return [];
+        }
+
+        $matches = glob($migrationsDir.'/*_create_escalated_*_table.php') ?: [];
+
+        return array_values($matches);
     }
 
     protected function publishEmailViews(bool $force): void

--- a/tests/Unit/InstallCommandTest.php
+++ b/tests/Unit/InstallCommandTest.php
@@ -357,3 +357,65 @@ it('returns null for non-App namespace models', function () {
 
     expect($path)->toBeNull();
 });
+
+// --- existingPublishedMigrations ---
+
+function seedFakeMigrationsDir(array $filenames): string
+{
+    $dir = sys_get_temp_dir().'/escalated-install-test-'.uniqid();
+    mkdir($dir.'/migrations', 0777, true);
+    foreach ($filenames as $name) {
+        file_put_contents($dir.'/migrations/'.$name, "<?php\n");
+    }
+    app()->useDatabasePath($dir);
+
+    return $dir;
+}
+
+it('returns empty array when no escalated migrations are published yet', function () {
+    seedFakeMigrationsDir([
+        '2024_01_01_000001_create_users_table.php',
+        '2024_01_01_000002_create_password_resets_table.php',
+    ]);
+
+    $result = callMethod(makeCommand(), 'existingPublishedMigrations');
+
+    expect($result)->toBe([]);
+});
+
+it('detects published escalated migrations by filename pattern', function () {
+    seedFakeMigrationsDir([
+        '2024_01_01_000001_create_users_table.php',
+        '2026_04_19_120000_create_escalated_departments_table.php',
+        '2026_04_19_120001_create_escalated_tickets_table.php',
+    ]);
+
+    $result = callMethod(makeCommand(), 'existingPublishedMigrations');
+
+    expect($result)->toHaveCount(2);
+    expect(basename($result[0]))->toContain('create_escalated_departments_table');
+    expect(basename($result[1]))->toContain('create_escalated_tickets_table');
+});
+
+it('does not match unrelated migrations that happen to mention escalated', function () {
+    seedFakeMigrationsDir([
+        '2024_01_01_000001_add_escalated_at_column_to_tickets.php',
+        '2026_04_19_120000_create_escalated_departments_table.php',
+    ]);
+
+    $result = callMethod(makeCommand(), 'existingPublishedMigrations');
+
+    // Pattern requires _create_escalated_*_table.php — first file must not match.
+    expect($result)->toHaveCount(1);
+    expect(basename($result[0]))->toContain('create_escalated_departments_table');
+});
+
+it('returns empty array when migrations directory does not exist', function () {
+    $dir = sys_get_temp_dir().'/escalated-install-test-'.uniqid();
+    mkdir($dir, 0777, true);
+    app()->useDatabasePath($dir);
+
+    $result = callMethod(makeCommand(), 'existingPublishedMigrations');
+
+    expect($result)->toBe([]);
+});


### PR DESCRIPTION
## Summary

- `InstallCommand::publishMigrations()` now detects previously-published Escalated migrations by the `*_create_escalated_*_table.php` filename pattern and short-circuits when the user re-runs `escalated:install` without `--force`.
- With `--force`, the old published copies are unlinked before the new batch is written, so there is always exactly one timestamped copy per table.
- Added 4 unit tests (`existingPublishedMigrations` behavior, including the no-match edge case where an unrelated migration happens to contain "escalated").
- Added a `migrations_already_published` translation key in all 14 locales.

Closes #61

## Why

Laravel's `publishesMigrations()` prepends the current timestamp to each file on every invocation. Running `escalated:install` twice therefore wrote 53 duplicate migrations (same table, different timestamp prefix). Subsequent `php artisan migrate` either failed or silently double-created tables. `--force` did not help because the duplicate filenames differ.

## Test plan

- [x] `vendor/bin/pest tests/Unit/InstallCommandTest.php` - 22 passed (18 existing + 4 new)
- [x] Manual repro: fresh Laravel app - `php artisan escalated:install` twice - second run now reports `53 Escalated migration(s) already published; skipping.` and leaves the directory with exactly one copy per table.
- [x] `--force` rerun deletes the stale copies and re-publishes with fresh timestamps.