### PR TITLE
fix: fall back to email-only search when users table lacks name column (#63)

### DIFF
--- a/config/escalated.php
+++ b/config/escalated.php
@@ -19,6 +19,18 @@ return [
     |--------------------------------------------------------------------------
     | User Model
     |--------------------------------------------------------------------------
+    |
+    | `user_display_column` is the column Escalated reads + searches to
+    | show the requester's human-readable name. Defaults to `name`.
+    |
+    | If your `users` table uses split columns (e.g. `first_name` /
+    | `last_name`) or any other schema without a single `name` column,
+    | point this at whichever column holds the display text (e.g.
+    | `'first_name'`). If the configured column doesn't exist on the
+    | table at all, Escalated silently falls back to searching the
+    | `email` column — so no code changes are required for hosts with
+    | non-standard user schemas.
+    |
     */
     'user_model' => env('ESCALATED_USER_MODEL', 'App\\Models\\User'),
     'user_display_column' => env('ESCALATED_USER_DISPLAY_COLUMN', 'name'),

--- a/src/Drivers/LocalDriver.php
+++ b/src/Drivers/LocalDriver.php
@@ -7,6 +7,7 @@ use Escalated\Laravel\Contracts\TicketDriver;
 use Escalated\Laravel\Enums\ActivityType;
 use Escalated\Laravel\Enums\TicketPriority;
 use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Escalated;
 use Escalated\Laravel\Events;
 use Escalated\Laravel\Models\Reply;
 use Escalated\Laravel\Models\Tag;
@@ -181,8 +182,7 @@ class LocalDriver implements TicketDriver
                 $q->where('guest_name', 'like', "%{$term}%")
                     ->orWhere('guest_email', 'like', "%{$term}%")
                     ->orWhereHas('requester', function ($rq) use ($term) {
-                        $rq->where('name', 'like', "%{$term}%")
-                            ->orWhere('email', 'like', "%{$term}%");
+                        Escalated::applyUserSearch($rq, $term);
                     });
             });
         }

--- a/src/Escalated.php
+++ b/src/Escalated.php
@@ -2,6 +2,9 @@
 
 namespace Escalated\Laravel;
 
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Facades\Schema;
+
 class Escalated
 {
     /**
@@ -13,6 +16,14 @@ class Escalated
      * The user display column.
      */
     public static string $userDisplayColumn = 'name';
+
+    /**
+     * Memoized per-process cache of `Schema::hasColumn` lookups so we
+     * don't round-trip the information_schema on every search query.
+     *
+     * @var array<string,bool>
+     */
+    private static array $columnExistsCache = [];
 
     /**
      * Set the user model class.
@@ -58,13 +69,87 @@ class Escalated
 
     /**
      * Get users as id => display_column array for select options.
+     *
+     * Falls back to `email` when the configured display column doesn't
+     * exist on the host's `users` table (e.g. hosts that store split
+     * `first_name`/`last_name` columns instead of a single `name`).
      */
     public static function userOptions(): array
     {
         $model = static::userModel();
-        $column = static::userDisplayColumn();
+        $column = static::userSearchableDisplayColumn();
 
         return $model::pluck($column, 'id')->toArray();
+    }
+
+    /**
+     * Resolve the effective display column to query against.
+     *
+     * Returns the configured `user_display_column` when that column
+     * exists on the user model's table, otherwise `'email'`. This lets
+     * hosts that don't have a `name` column (the default) still get
+     * sensible search/pluck behavior without changing any code.
+     */
+    public static function userSearchableDisplayColumn(): string
+    {
+        $configured = static::userDisplayColumn();
+        if (static::userHasColumn($configured)) {
+            return $configured;
+        }
+
+        return 'email';
+    }
+
+    /**
+     * Apply a requester search term to a user-model query.
+     *
+     * Searches the configured display column (typically `name`) and
+     * `email`. When the display column doesn't exist on the host's
+     * users table, silently degrades to an email-only search — this is
+     * the fallback contract documented in issue #63.
+     *
+     * @param  Builder  $query  The inner query (an already-scoped user query,
+     *                          usually from `whereHas('requester', ...)`)
+     */
+    public static function applyUserSearch(Builder $query, string $term): Builder
+    {
+        $displayColumn = static::userDisplayColumn();
+        $hasDisplay = static::userHasColumn($displayColumn);
+
+        if ($hasDisplay && $displayColumn !== 'email') {
+            return $query->where($displayColumn, 'like', "%{$term}%")
+                ->orWhere('email', 'like', "%{$term}%");
+        }
+
+        // Display column is missing (or is literally 'email'); search email only.
+        return $query->where('email', 'like', "%{$term}%");
+    }
+
+    /**
+     * Check whether the configured user model's table exposes the given
+     * column. Results are memoized per process because Schema lookups
+     * hit information_schema.
+     */
+    protected static function userHasColumn(string $column): bool
+    {
+        $model = static::userModel();
+        $table = (new $model)->getTable();
+        $key = "{$table}.{$column}";
+
+        if (! array_key_exists($key, static::$columnExistsCache)) {
+            static::$columnExistsCache[$key] = Schema::hasColumn($table, $column);
+        }
+
+        return static::$columnExistsCache[$key];
+    }
+
+    /**
+     * Clear the schema cache. Intended for use in tests that recreate
+     * the users table with different column sets.
+     */
+    public static function flushColumnCache(): void
+    {
+        static::$columnExistsCache = [];
     }
 
     /**

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -263,8 +263,7 @@ class Ticket extends Model
                 ->orWhere('guest_name', 'like', "%{$term}%")
                 ->orWhere('guest_email', 'like', "%{$term}%")
                 ->orWhereHas('requester', function ($rq) use ($term) {
-                    $rq->where('name', 'like', "%{$term}%")
-                        ->orWhere('email', 'like', "%{$term}%");
+                    Escalated::applyUserSearch($rq, $term);
                 });
         });
     }

--- a/tests/Unit/UserSearchTest.php
+++ b/tests/Unit/UserSearchTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Escalated\Laravel\Tests\Unit;
+
+use Escalated\Laravel\Escalated;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Tests\Fixtures\TestUser;
+use Escalated\Laravel\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Regression tests for https://github.com/escalated-dev/escalated-laravel/issues/63
+ *
+ * When the host's `users` table doesn't have a `name` column (e.g. it
+ * uses split `first_name` / `last_name` or any other schema), the
+ * ticket search must silently fall back to searching `email` instead
+ * of raising `column users.name does not exist`.
+ */
+class UserSearchTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Escalated::flushColumnCache();
+        parent::tearDown();
+    }
+
+    public function test_search_uses_configured_display_column_when_it_exists(): void
+    {
+        $user = TestUser::create([
+            'name' => 'Alice',
+            'email' => 'alice@example.com',
+            'password' => bcrypt('x'),
+        ]);
+
+        Ticket::factory()->create([
+            'requester_type' => TestUser::class,
+            'requester_id' => $user->id,
+            'subject' => 'Broken widget',
+        ]);
+
+        $results = Ticket::search('Alice')->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_search_falls_back_to_email_when_display_column_missing(): void
+    {
+        // Simulate a host whose users table lacks a `name` column by
+        // dropping it before the cache is warmed.
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+        Escalated::flushColumnCache();
+
+        // Use a model subclass so we can insert without `name` (the
+        // fixture model's `$fillable` and created_at timestamps still
+        // work; `name` just isn't set).
+        $user = new class extends Model
+        {
+            protected $table = 'users';
+
+            protected $guarded = [];
+
+            public $timestamps = true;
+        };
+        $user->fill([
+            'email' => 'bob@example.com',
+            'password' => bcrypt('x'),
+        ])->save();
+
+        Ticket::factory()->create([
+            'requester_type' => TestUser::class,
+            'requester_id' => $user->id,
+            'subject' => 'Widget fell off',
+        ]);
+
+        // Search by email substring — works even though the column
+        // `name` doesn't exist on the table. Prior to the fix this
+        // threw "column users.name does not exist" against Postgres
+        // and silently returned an empty result on sqlite (because
+        // `WHERE name LIKE ...` evaluates to NULL against a missing
+        // column in sqlite's lenient mode).
+        $results = Ticket::search('bob')->get();
+        $this->assertCount(1, $results);
+    }
+
+    public function test_apply_user_search_helper_skips_missing_column(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+        Escalated::flushColumnCache();
+
+        // Inspect the generated SQL to confirm it no longer references
+        // `users.name`.
+        $query = TestUser::query()->getQuery();
+        Escalated::applyUserSearch(TestUser::query()->getQuery(), 'test');
+
+        // Rebuild a fresh builder to capture the where clauses the
+        // helper applies.
+        $builder = TestUser::query()->getQuery();
+        Escalated::applyUserSearch($builder, 'test');
+
+        $sql = $builder->toSql();
+        $this->assertStringNotContainsString('"name"', $sql);
+        $this->assertStringContainsString('"email"', $sql);
+    }
+
+    public function test_user_options_falls_back_to_email_when_column_missing(): void
+    {
+        TestUser::create([
+            'name' => 'ignored', // will be dropped below, but required by the existing schema for now
+            'email' => 'ann@example.com',
+            'password' => bcrypt('x'),
+        ]);
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+        Escalated::flushColumnCache();
+
+        $options = Escalated::userOptions();
+
+        $this->assertNotEmpty($options);
+        $this->assertContains('ann@example.com', array_values($options));
+    }
+}


### PR DESCRIPTION
## Why

Closes #63.

From the issue: Escalated's ticket search (agent + customer areas) assumed a \`name\` column on the \`users\` table. Hosts that use split \`first_name\` / \`last_name\` columns — or any schema without a single \`name\` field — would hit \`column users.name does not exist\` against Postgres (or silently return empty against sqlite).

The \`user_display_column\` config option already existed for the **read side** (\`Escalated::userOptions\`, \`HasTickets::ticketable_name\`), but the two **search call sites** bypassed it and hardcoded \`where('name', ...)->orWhere('email', ...)\`:

- \`src/Models/Ticket.php\` \`scopeSearch\`
- \`src/Drivers/LocalDriver.php\` requester filter

## What

Route both through a new \`Escalated::applyUserSearch(\$query, \$term)\` helper that:

1. reads the configured display column
2. checks \`Schema::hasColumn\` once per process (memoized — info_schema roundtrips aren't free)
3. if the column exists, searches \`display_column OR email\`
4. otherwise, silently degrades to email-only search (the fallback promised in the issue thread)

\`Escalated::userOptions()\` now pivots through a new \`userSearchableDisplayColumn()\` accessor, so the admin "assign requester" dropdowns also gracefully degrade.

No behavior change for hosts with a standard \`name\` column. Hosts with non-standard schemas get working search out of the box; setting \`ESCALATED_USER_DISPLAY_COLUMN=first_name\` (or any column they actually have) flows through correctly too.

Config comment updated to document both paths.

## Tests

New \`tests/Unit/UserSearchTest.php\` covers four scenarios:

- search works through the configured display column when it exists
- search falls back to email-only after the column is dropped
- the generated SQL from \`applyUserSearch\` no longer references the missing column
- \`Escalated::userOptions()\` pivots to email when the display column is gone

\`\`\`
Tests:    4 passed (6 assertions)
Duration: 1.46s
\`\`\`

Existing admin + agent ticket suites continue to pass (\`pest tests/Feature/Admin/ControllerTest.php tests/Feature/Agent/TicketControllerTest.php\` — 20 passed, 29 assertions).