### PR TITLE
fix(customer): pass priority filter through to the driver (#64)

### DIFF
--- a/src/Http/Controllers/Customer/TicketController.php
+++ b/src/Http/Controllers/Customer/TicketController.php
@@ -21,14 +21,25 @@ class TicketController extends Controller
 
     public function index(Request $request): mixed
     {
+        // Customer-visible filter surface. Keep this in sync with the
+        // `TicketFilters.vue` component's `filterData` keys so every
+        // control the customer can see actually reaches the driver.
+        // (Historically `priority` was omitted here even though the UI
+        // exposed a priority dropdown — see #64.)
+        $filterKeys = [
+            'status', 'priority', 'ticket_type', 'search',
+            'tag', 'has_attachments', 'created_after', 'created_before',
+            'sort_by', 'sort_dir',
+        ];
+
         $tickets = $this->ticketService->list(
-            $request->only(['status', 'search', 'sort_by', 'sort_dir']),
+            $request->only($filterKeys),
             $request->user()
         );
 
         return $this->renderer->render('Escalated/Customer/Index', [
             'tickets' => $tickets,
-            'filters' => $request->only(['status', 'search']),
+            'filters' => $request->only($filterKeys),
         ]);
     }
 

--- a/tests/Unit/PriorityFilterTest.php
+++ b/tests/Unit/PriorityFilterTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Escalated\Laravel\Tests\Unit;
+
+use Escalated\Laravel\Enums\TicketPriority;
+use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Services\TicketService;
+use Escalated\Laravel\Tests\TestCase;
+
+/**
+ * Regression for https://github.com/escalated-dev/escalated-laravel/issues/64
+ *
+ * The driver always applied the priority filter correctly, but the
+ * customer controller's `$request->only(...)` projection was missing
+ * `priority` (while agent/admin/api all had it). The customer
+ * `TicketFilters.vue` UI still rendered a priority dropdown, so the
+ * param hit the URL but was silently dropped before reaching the
+ * driver — the list returned all priorities regardless of the filter.
+ */
+class PriorityFilterTest extends TestCase
+{
+    public function test_driver_applies_priority_filter(): void
+    {
+        Ticket::factory()->create([
+            'priority' => TicketPriority::Low,
+            'subject' => 'low one',
+        ]);
+        Ticket::factory()->create([
+            'priority' => TicketPriority::Urgent,
+            'subject' => 'urgent one',
+        ]);
+
+        $service = app(TicketService::class);
+        $results = $service->list(['priority' => 'urgent']);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('urgent one', $results->items()[0]->subject);
+    }
+
+    public function test_agent_index_filters_by_priority(): void
+    {
+        \Illuminate\Support\Facades\Gate::define('escalated-agent', fn () => true);
+        \Illuminate\Support\Facades\Gate::define('escalated-admin', fn () => true);
+
+        $agent = $this->createAgent();
+        Ticket::factory()->create(['priority' => TicketPriority::Low, 'subject' => 'low one']);
+        Ticket::factory()->create(['priority' => TicketPriority::Urgent, 'subject' => 'urgent one']);
+
+        $response = $this->actingAs($agent)
+            ->get(route('escalated.agent.tickets.index', ['priority' => 'urgent']));
+
+        $response->assertOk();
+        $props = $response->viewData('page')['props'] ?? null;
+        if ($props) {
+            $tickets = $props['tickets']['data'] ?? [];
+            $this->assertCount(1, $tickets, 'Agent priority filter should return 1 urgent ticket');
+            $this->assertSame('urgent one', $tickets[0]['subject']);
+        } else {
+            $this->markTestIncomplete('Could not extract Inertia props from agent response');
+        }
+    }
+
+    public function test_agent_index_filters_by_status_and_priority_together(): void
+    {
+        // Reproduce the Clockwork scenario from the bug report: both
+        // status and priority set on the URL at the same time.
+        \Illuminate\Support\Facades\Gate::define('escalated-agent', fn () => true);
+        \Illuminate\Support\Facades\Gate::define('escalated-admin', fn () => true);
+
+        $agent = $this->createAgent();
+        Ticket::factory()->create([
+            'status' => TicketStatus::Open,
+            'priority' => TicketPriority::Low,
+            'subject' => 'open low',
+        ]);
+        Ticket::factory()->create([
+            'status' => TicketStatus::Open,
+            'priority' => TicketPriority::Urgent,
+            'subject' => 'open urgent',
+        ]);
+        Ticket::factory()->create([
+            'status' => TicketStatus::Closed,
+            'priority' => TicketPriority::Urgent,
+            'subject' => 'closed urgent',
+        ]);
+
+        $response = $this->actingAs($agent)
+            ->get(route('escalated.agent.tickets.index', [
+                'status' => 'open',
+                'priority' => 'urgent',
+            ]));
+
+        $response->assertOk();
+        $props = $response->viewData('page')['props'] ?? null;
+        if ($props) {
+            $tickets = $props['tickets']['data'] ?? [];
+            $this->assertCount(1, $tickets, 'Agent status+priority filter should return 1 matching ticket');
+            $this->assertSame('open urgent', $tickets[0]['subject']);
+        } else {
+            $this->markTestIncomplete('Could not extract Inertia props from agent response');
+        }
+    }
+
+    public function test_customer_index_filters_by_priority(): void
+    {
+        $customer = $this->createTestUser();
+
+        Ticket::factory()->create([
+            'priority' => TicketPriority::Low,
+            'subject' => 'cust low',
+            'requester_type' => $customer->getMorphClass(),
+            'requester_id' => $customer->getKey(),
+        ]);
+        Ticket::factory()->create([
+            'priority' => TicketPriority::Urgent,
+            'subject' => 'cust urgent',
+            'requester_type' => $customer->getMorphClass(),
+            'requester_id' => $customer->getKey(),
+        ]);
+
+        $response = $this->actingAs($customer)
+            ->get(route('escalated.customer.tickets.index', ['priority' => 'urgent']));
+
+        $response->assertOk();
+        $props = $response->viewData('page')['props'] ?? null;
+        if ($props) {
+            $tickets = $props['tickets']['data'] ?? [];
+            $this->assertCount(1, $tickets, 'Customer priority filter should return 1 urgent ticket');
+            $this->assertSame('cust urgent', $tickets[0]['subject']);
+        } else {
+            $this->markTestIncomplete('Could not extract Inertia props from customer response');
+        }
+    }
+}

--- a/tests/Unit/PriorityFilterTest.php
+++ b/tests/Unit/PriorityFilterTest.php
@@ -7,6 +7,7 @@ use Escalated\Laravel\Enums\TicketStatus;
 use Escalated\Laravel\Models\Ticket;
 use Escalated\Laravel\Services\TicketService;
 use Escalated\Laravel\Tests\TestCase;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * Regression for https://github.com/escalated-dev/escalated-laravel/issues/64
@@ -40,8 +41,8 @@ class PriorityFilterTest extends TestCase
 
     public function test_agent_index_filters_by_priority(): void
     {
-        \Illuminate\Support\Facades\Gate::define('escalated-agent', fn () => true);
-        \Illuminate\Support\Facades\Gate::define('escalated-admin', fn () => true);
+        Gate::define('escalated-agent', fn () => true);
+        Gate::define('escalated-admin', fn () => true);
 
         $agent = $this->createAgent();
         Ticket::factory()->create(['priority' => TicketPriority::Low, 'subject' => 'low one']);
@@ -65,8 +66,8 @@ class PriorityFilterTest extends TestCase
     {
         // Reproduce the Clockwork scenario from the bug report: both
         // status and priority set on the URL at the same time.
-        \Illuminate\Support\Facades\Gate::define('escalated-agent', fn () => true);
-        \Illuminate\Support\Facades\Gate::define('escalated-admin', fn () => true);
+        Gate::define('escalated-agent', fn () => true);
+        Gate::define('escalated-admin', fn () => true);
 
         $agent = $this->createAgent();
         Ticket::factory()->create([


### PR DESCRIPTION
## Why

Closes #64.

The customer \`TicketController@index\` dropped the \`priority\` URL param before it reached the driver:

\`\`\`php
\$request->only(['status', 'search', 'sort_by', 'sort_dir'])
//              ^^^ priority missing
\`\`\`

\`TicketFilters.vue\` (the shared Vue component the customer ticket list uses) still renders a priority dropdown, so the param landed in the URL — but the backend's \`only()\` projection silently stripped it before calling \`TicketService::list()\`. **The driver was fine; the filter was never given to it.** Status/search worked by coincidence because those keys happened to be in the allow-list.

Agent / admin / api were never affected (their \`only()\` lists already include \`priority\` — I added regression tests for the agent path to prove this). Driver always applied the filter correctly when it received it.

## Fix

Expand the customer \`only()\` list to match the keys \`TicketFilters.vue\` actually sends:

\`status\`, \`priority\`, \`ticket_type\`, \`search\`, \`tag\`, \`has_attachments\`, \`created_after\`, \`created_before\`, plus \`sort_by\` / \`sort_dir\`.

Deliberately excluded: \`assigned_to\`, \`unassigned\`, \`sla_breached\`, \`snoozed\`, \`live_chat\`, \`following\`, \`department_id\` — those are agent-only concerns we don't want customers filtering their own tickets by.

Also extracted a single \`\$filterKeys\` variable so the \`list()\` filter projection and the Inertia \`filters\` prop can't drift apart the way they did before (the prop was previously hardcoded to only \`status\` + \`search\`).

## Tests

New \`tests/Unit/PriorityFilterTest.php\` with four cases:

1. **driver applies priority** — proves the driver side was never broken.
2. **agent index filters by priority alone** — proves agent path was never broken.
3. **agent index filters by status + priority together** — reproduces the exact Clockwork scenario in the bug report.
4. **customer index filters by priority** — the actual regression. Fails on \`main\`, passes after this PR.

\`\`\`
Tests:    4 passed (11 assertions)
Duration: 1.55s
\`\`\`

The 7 existing \`Feature/Customer/TicketControllerTest\` cases continue to pass.