### PR TITLE
feat(mail): add MessageIdUtil for RFC 5322 threading + signed Reply-To

### DIFF
--- a/src/Mail/MessageIdUtil.php
+++ b/src/Mail/MessageIdUtil.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Escalated\Laravel\Mail;
+
+/**
+ * Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+ * addresses. Mirrors the NestJS reference
+ * `escalated-nestjs/src/services/email/message-id.ts` and the Spring /
+ * WordPress / .NET / Phoenix ports.
+ *
+ * ## Message-ID format
+ *   <ticket-{ticketId}@{domain}>             initial ticket email
+ *   <ticket-{ticketId}-reply-{replyId}@{domain}>  agent reply
+ *
+ * ## Signed Reply-To format
+ *   reply+{ticketId}.{hmac8}@{domain}
+ *
+ * The signed Reply-To carries ticket identity even when clients strip
+ * our Message-ID / In-Reply-To headers — the inbound provider webhook
+ * verifies the 8-char HMAC-SHA256 prefix before routing a reply to
+ * its ticket.
+ */
+class MessageIdUtil
+{
+    /**
+     * Build an RFC 5322 Message-ID. Pass `null` for `$replyId` on the
+     * initial ticket email; the `-reply-{id}` tail is appended only
+     * when `$replyId` is non-null.
+     */
+    public static function buildMessageId(int $ticketId, ?int $replyId, string $domain): string
+    {
+        $body = $replyId !== null
+            ? sprintf('ticket-%d-reply-%d', $ticketId, $replyId)
+            : sprintf('ticket-%d', $ticketId);
+
+        return sprintf('<%s@%s>', $body, $domain);
+    }
+
+    /**
+     * Extract the ticket id from a Message-ID we issued. Accepts the
+     * header value with or without angle brackets. Returns `null` when
+     * the input doesn't match our shape.
+     */
+    public static function parseTicketIdFromMessageId(?string $raw): ?int
+    {
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        if (preg_match('/ticket-(\d+)(?:-reply-\d+)?@/i', $raw, $m)) {
+            return (int) $m[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Build a signed Reply-To address of the form
+     * `reply+{ticketId}.{hmac8}@{domain}`.
+     */
+    public static function buildReplyTo(int $ticketId, string $secret, string $domain): string
+    {
+        return sprintf('reply+%d.%s@%s', $ticketId, self::sign($ticketId, $secret), $domain);
+    }
+
+    /**
+     * Verify a reply-to address (full `local@domain` or just the local
+     * part). Returns the ticket id on match, `null` otherwise. Uses
+     * `hash_equals` for timing-safe comparison.
+     */
+    public static function verifyReplyTo(?string $address, string $secret): ?int
+    {
+        if ($address === null || $address === '') {
+            return null;
+        }
+        $at = strpos($address, '@');
+        $local = $at !== false ? substr($address, 0, $at) : $address;
+        if (! preg_match('/^reply\+(\d+)\.([a-f0-9]{8})$/i', $local, $m)) {
+            return null;
+        }
+        $ticketId = (int) $m[1];
+        $expected = self::sign($ticketId, $secret);
+
+        return hash_equals(strtolower($expected), strtolower($m[2])) ? $ticketId : null;
+    }
+
+    /**
+     * 8-character HMAC-SHA256 prefix over the ticket id.
+     */
+    private static function sign(int $ticketId, string $secret): string
+    {
+        return substr(hash_hmac('sha256', (string) $ticketId, $secret), 0, 8);
+    }
+}

--- a/tests/Unit/MessageIdUtilTest.php
+++ b/tests/Unit/MessageIdUtilTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Escalated\Laravel\Tests\Unit;
+
+use Escalated\Laravel\Mail\MessageIdUtil;
+use Escalated\Laravel\Tests\TestCase;
+
+/**
+ * Pure-function tests for MessageIdUtil. Mirrors the NestJS / Spring /
+ * WordPress / .NET / Phoenix reference test suites.
+ */
+class MessageIdUtilTest extends TestCase
+{
+    private const DOMAIN = 'support.example.com';
+
+    private const SECRET = 'test-secret-long-enough-for-hmac';
+
+    public function test_build_message_id_initial_ticket(): void
+    {
+        $this->assertEquals(
+            '<ticket-42@support.example.com>',
+            MessageIdUtil::buildMessageId(42, null, self::DOMAIN)
+        );
+    }
+
+    public function test_build_message_id_reply_form(): void
+    {
+        $this->assertEquals(
+            '<ticket-42-reply-7@support.example.com>',
+            MessageIdUtil::buildMessageId(42, 7, self::DOMAIN)
+        );
+    }
+
+    public function test_parse_ticket_id_round_trips(): void
+    {
+        $initial = MessageIdUtil::buildMessageId(42, null, self::DOMAIN);
+        $reply = MessageIdUtil::buildMessageId(42, 7, self::DOMAIN);
+
+        $this->assertEquals(42, MessageIdUtil::parseTicketIdFromMessageId($initial));
+        $this->assertEquals(42, MessageIdUtil::parseTicketIdFromMessageId($reply));
+    }
+
+    public function test_parse_ticket_id_accepts_value_without_brackets(): void
+    {
+        $this->assertEquals(99, MessageIdUtil::parseTicketIdFromMessageId('ticket-99@example.com'));
+    }
+
+    public function test_parse_ticket_id_returns_null_for_unrelated_input(): void
+    {
+        $this->assertNull(MessageIdUtil::parseTicketIdFromMessageId(null));
+        $this->assertNull(MessageIdUtil::parseTicketIdFromMessageId(''));
+        $this->assertNull(MessageIdUtil::parseTicketIdFromMessageId('<random@mail.com>'));
+        $this->assertNull(MessageIdUtil::parseTicketIdFromMessageId('ticket-abc@example.com'));
+    }
+
+    public function test_build_reply_to_is_stable(): void
+    {
+        $first = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $again = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $this->assertEquals($first, $again);
+        $this->assertMatchesRegularExpression(
+            '/^reply\+42\.[a-f0-9]{8}@support\.example\.com$/',
+            $first
+        );
+    }
+
+    public function test_build_reply_to_different_tickets_differ(): void
+    {
+        $a = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $b = MessageIdUtil::buildReplyTo(43, self::SECRET, self::DOMAIN);
+        $this->assertNotEquals(
+            substr($a, 0, strpos($a, '@')),
+            substr($b, 0, strpos($b, '@'))
+        );
+    }
+
+    public function test_verify_reply_to_round_trips(): void
+    {
+        $address = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $this->assertEquals(42, MessageIdUtil::verifyReplyTo($address, self::SECRET));
+    }
+
+    public function test_verify_reply_to_accepts_local_part_only(): void
+    {
+        $address = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $local = substr($address, 0, strpos($address, '@'));
+        $this->assertEquals(42, MessageIdUtil::verifyReplyTo($local, self::SECRET));
+    }
+
+    public function test_verify_reply_to_rejects_tampered_signature(): void
+    {
+        $address = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $at = strpos($address, '@');
+        $local = substr($address, 0, $at);
+        $last = $local[strlen($local) - 1];
+        $tampered = substr($local, 0, -1).($last === '0' ? '1' : '0').substr($address, $at);
+        $this->assertNull(MessageIdUtil::verifyReplyTo($tampered, self::SECRET));
+    }
+
+    public function test_verify_reply_to_rejects_wrong_secret(): void
+    {
+        $address = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $this->assertNull(MessageIdUtil::verifyReplyTo($address, 'different-secret'));
+    }
+
+    public function test_verify_reply_to_rejects_malformed_input(): void
+    {
+        $this->assertNull(MessageIdUtil::verifyReplyTo(null, self::SECRET));
+        $this->assertNull(MessageIdUtil::verifyReplyTo('', self::SECRET));
+        $this->assertNull(MessageIdUtil::verifyReplyTo('alice@example.com', self::SECRET));
+        $this->assertNull(MessageIdUtil::verifyReplyTo('reply@example.com', self::SECRET));
+        $this->assertNull(MessageIdUtil::verifyReplyTo('reply+abc.deadbeef@example.com', self::SECRET));
+    }
+
+    public function test_verify_reply_to_case_insensitive_hex(): void
+    {
+        $address = MessageIdUtil::buildReplyTo(42, self::SECRET, self::DOMAIN);
+        $this->assertEquals(42, MessageIdUtil::verifyReplyTo(strtoupper($address), self::SECRET));
+    }
+}


### PR DESCRIPTION
## Summary

Ports the NestJS `email/message-id.ts` helpers to Laravel. Mirrors the Spring / WordPress / .NET / Phoenix ports (4 of 11 framework ports shipped so far).

## API

- `buildMessageId(ticketId, replyId, domain)`
- `parseTicketIdFromMessageId(raw)`
- `buildReplyTo(ticketId, secret, domain)`
- `verifyReplyTo(address, secret)`

Uses `hash_hmac('sha256', ...)` + `hash_equals` for timing-safe comparison.

## Scope

**Utility only.** Follow-up PR will:

1. Migrate `NewTicketNotification` / `SlaBreachNotification` inline `'ticket-'.$ticket->id.'@'.$domain` building to use this util
2. Set signed Reply-To on outbound mailers
3. Extend the Mailgun / Postmark inbound adapters to call `verifyReplyTo` for ticket-identity routing

## Test plan

- [x] 13 PHPUnit tests covering round-trip, tamper rejection, case-insensitive hex, malformed input, local-part-only
- [ ] CI green: `test`, `lint`