### PR TITLE
feat(mail): wire MessageIdUtil into all 7 ticket notifications

### DIFF
--- a/config/escalated.php
+++ b/config/escalated.php
@@ -149,6 +149,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Email (outbound + inbound)
+    |--------------------------------------------------------------------------
+    |
+    | `domain` is the right-hand side of RFC 5322 Message-IDs and
+    | signed Reply-To addresses. Defaults to the host parsed from
+    | APP_URL, then falls back to "escalated.dev".
+    |
+    | `inbound_secret` is the HMAC key used to sign the Reply-To local
+    | part (reply+{id}.{hmac8}@domain). When empty, Reply-To is left
+    | untouched — basic threading still works via Message-ID /
+    | In-Reply-To, but inbound providers can't verify ticket identity.
+    |
+    */
+    'email' => [
+        'domain' => env('ESCALATED_EMAIL_DOMAIN'),
+        'inbound_secret' => env('ESCALATED_EMAIL_INBOUND_SECRET', ''),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Storage (Attachments)
     |--------------------------------------------------------------------------
     */

--- a/src/Mail/NotificationThreading.php
+++ b/src/Mail/NotificationThreading.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Escalated\Laravel\Mail;
+
+use Escalated\Laravel\Models\Ticket;
+use Symfony\Component\Mime\Email;
+
+/**
+ * Helper that applies RFC 5322 threading headers + signed Reply-To to
+ * a Symfony Mailer {@see Email} from within Notification
+ * `withSymfonyMessage` callbacks.
+ *
+ * Centralizes the threading logic so every notification points replies
+ * back to the canonical ticket thread and the signed Reply-To routes
+ * inbound mail back to the correct ticket even when clients strip
+ * Message-ID / In-Reply-To headers.
+ *
+ * Uses {@see MessageIdUtil} for the actual header building.
+ *
+ * ## Usage
+ *
+ * Initial ticket notification (sets the thread anchor):
+ *
+ *     ->withSymfonyMessage(fn ($message) =>
+ *         NotificationThreading::applyAnchor($message, $ticket))
+ *
+ * Reply-to-thread notifications (SLA, assigned, status change, etc.):
+ *
+ *     ->withSymfonyMessage(fn ($message) =>
+ *         NotificationThreading::applyThread($message, $ticket))
+ *
+ * Agent-reply notification (sets own Message-ID too):
+ *
+ *     ->withSymfonyMessage(fn ($message) =>
+ *         NotificationThreading::applyThread($message, $ticket, $replyId))
+ */
+class NotificationThreading
+{
+    /**
+     * Apply thread-anchor headers: set Message-ID to the ticket root.
+     * Use on the initial ticket-created notification — this is the
+     * anchor every subsequent message in the thread references.
+     */
+    public static function applyAnchor(Email $message, Ticket $ticket): void
+    {
+        $rootId = MessageIdUtil::buildMessageId((int) $ticket->id, null, self::domain());
+        $message->getHeaders()->remove('Message-ID');
+        // addIdHeader wraps the id in angle brackets for us.
+        $message->getHeaders()->addIdHeader('Message-ID', self::stripAngles($rootId));
+
+        self::applySignedReplyTo($message, $ticket);
+    }
+
+    /**
+     * Apply thread-reply headers so the message joins the ticket's
+     * thread. When `$replyId` is given, also sets the message's own
+     * Message-ID to `<ticket-id-reply-replyId@domain>`.
+     */
+    public static function applyThread(Email $message, Ticket $ticket, ?int $replyId = null): void
+    {
+        $rootId = MessageIdUtil::buildMessageId((int) $ticket->id, null, self::domain());
+        $headers = $message->getHeaders();
+
+        $headers->addIdHeader('In-Reply-To', self::stripAngles($rootId));
+        $headers->addIdHeader('References', self::stripAngles($rootId));
+
+        if ($replyId !== null) {
+            $messageId = MessageIdUtil::buildMessageId((int) $ticket->id, $replyId, self::domain());
+            $headers->remove('Message-ID');
+            $headers->addIdHeader('Message-ID', self::stripAngles($messageId));
+        }
+
+        self::applySignedReplyTo($message, $ticket);
+    }
+
+    /**
+     * Set a signed Reply-To so the inbound provider webhook can verify
+     * ticket identity without trusting client-side headers. Skipped
+     * when `escalated.email.inbound_secret` is unset (empty default).
+     */
+    protected static function applySignedReplyTo(Email $message, Ticket $ticket): void
+    {
+        $secret = (string) config('escalated.email.inbound_secret', '');
+        if ($secret === '') {
+            return;
+        }
+        $replyTo = MessageIdUtil::buildReplyTo((int) $ticket->id, $secret, self::domain());
+        $message->replyTo($replyTo);
+    }
+
+    protected static function domain(): string
+    {
+        $configured = (string) config('escalated.email.domain', '');
+        if ($configured !== '') {
+            return $configured;
+        }
+        $host = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+        return $host ?: 'escalated.dev';
+    }
+
+    /**
+     * Symfony's addIdHeader wraps the value in angle brackets itself,
+     * so pass the bare `ticket-42@domain` part without the `<>`.
+     */
+    protected static function stripAngles(string $messageId): string
+    {
+        return trim($messageId, '<>');
+    }
+}

--- a/src/Notifications/NewTicketNotification.php
+++ b/src/Notifications/NewTicketNotification.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Notifications;
 
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Ticket;
 use Illuminate\Bus\Queueable;
@@ -38,10 +39,7 @@ class NewTicketNotification extends Notification implements ShouldQueue
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->remove('Message-ID');
-                $message->getHeaders()->addIdHeader('Message-ID', $threadId);
+                NotificationThreading::applyAnchor($message, $ticket);
             });
     }
 

--- a/src/Notifications/SlaBreachNotification.php
+++ b/src/Notifications/SlaBreachNotification.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Notifications;
 
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Ticket;
 use Illuminate\Bus\Queueable;
@@ -44,10 +45,7 @@ class SlaBreachNotification extends Notification implements ShouldQueue
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->addIdHeader('In-Reply-To', $threadId);
-                $message->getHeaders()->addIdHeader('References', $threadId);
+                NotificationThreading::applyThread($message, $ticket);
             });
     }
 

--- a/src/Notifications/TicketAssignedNotification.php
+++ b/src/Notifications/TicketAssignedNotification.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Notifications;
 
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Ticket;
 use Illuminate\Bus\Queueable;
@@ -37,10 +38,7 @@ class TicketAssignedNotification extends Notification implements ShouldQueue
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->addIdHeader('In-Reply-To', $threadId);
-                $message->getHeaders()->addIdHeader('References', $threadId);
+                NotificationThreading::applyThread($message, $ticket);
             });
     }
 

--- a/src/Notifications/TicketEscalatedNotification.php
+++ b/src/Notifications/TicketEscalatedNotification.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Notifications;
 
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Ticket;
 use Illuminate\Bus\Queueable;
@@ -42,10 +43,7 @@ class TicketEscalatedNotification extends Notification implements ShouldQueue
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->addIdHeader('In-Reply-To', $threadId);
-                $message->getHeaders()->addIdHeader('References', $threadId);
+                NotificationThreading::applyThread($message, $ticket);
             });
     }
 

--- a/src/Notifications/TicketReplyNotification.php
+++ b/src/Notifications/TicketReplyNotification.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Notifications;
 
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Reply;
 use Illuminate\Bus\Queueable;
@@ -39,10 +40,7 @@ class TicketReplyNotification extends Notification implements ShouldQueue
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->addIdHeader('In-Reply-To', $threadId);
-                $message->getHeaders()->addIdHeader('References', $threadId);
+                NotificationThreading::applyThread($message, $ticket, (int) $this->reply->id);
             });
     }
 

--- a/src/Notifications/TicketResolvedNotification.php
+++ b/src/Notifications/TicketResolvedNotification.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Notifications;
 
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Ticket;
 use Illuminate\Bus\Queueable;
@@ -37,10 +38,7 @@ class TicketResolvedNotification extends Notification implements ShouldQueue
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->addIdHeader('In-Reply-To', $threadId);
-                $message->getHeaders()->addIdHeader('References', $threadId);
+                NotificationThreading::applyThread($message, $ticket);
             });
     }
 

--- a/src/Notifications/TicketStatusChangedNotification.php
+++ b/src/Notifications/TicketStatusChangedNotification.php
@@ -3,6 +3,7 @@
 namespace Escalated\Laravel\Notifications;
 
 use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Mail\NotificationThreading;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\Ticket;
 use Illuminate\Bus\Queueable;
@@ -45,10 +46,7 @@ class TicketStatusChangedNotification extends Notification implements ShouldQueu
                 'footerText' => EscalatedSettings::get('email_footer_text'),
             ])
             ->withSymfonyMessage(function ($message) use ($ticket) {
-                $domain = parse_url(config('app.url'), PHP_URL_HOST) ?: 'escalated.dev';
-                $threadId = 'ticket-'.$ticket->id.'@'.$domain;
-                $message->getHeaders()->addIdHeader('In-Reply-To', $threadId);
-                $message->getHeaders()->addIdHeader('References', $threadId);
+                NotificationThreading::applyThread($message, $ticket);
             });
     }
 

--- a/tests/Unit/NotificationThreadingIntegrationTest.php
+++ b/tests/Unit/NotificationThreadingIntegrationTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Escalated\Laravel\Tests\Unit;
+
+use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Models\Reply;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Notifications\NewTicketNotification;
+use Escalated\Laravel\Notifications\SlaBreachNotification;
+use Escalated\Laravel\Notifications\TicketAssignedNotification;
+use Escalated\Laravel\Notifications\TicketEscalatedNotification;
+use Escalated\Laravel\Notifications\TicketReplyNotification;
+use Escalated\Laravel\Notifications\TicketResolvedNotification;
+use Escalated\Laravel\Notifications\TicketStatusChangedNotification;
+use Escalated\Laravel\Tests\TestCase;
+use Symfony\Component\Mime\Email;
+
+/**
+ * End-to-end tests confirming every notification's
+ * withSymfonyMessage callback writes the canonical Message-ID /
+ * In-Reply-To / References / Reply-To headers onto the underlying
+ * Symfony Email.
+ *
+ * Complements NotificationThreadingTest (which exercises the helper
+ * in isolation) by running each notification's closure against a
+ * real Email and asserting the final header output.
+ */
+class NotificationThreadingIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('escalated.email.domain', 'support.example.com');
+        config()->set('escalated.email.inbound_secret', 'test-secret');
+    }
+
+    private function runCallbacksOn(Email $email, $mail): void
+    {
+        foreach ($mail->callbacks as $cb) {
+            $cb($email);
+        }
+    }
+
+    public function test_new_ticket_notification_applies_anchor_headers(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $user = $this->createTestUser();
+        $mail = (new NewTicketNotification($ticket))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertSame(
+            "ticket-{$ticket->id}@support.example.com",
+            trim((string) $email->getHeaders()->get('Message-ID')->getId(), '<>')
+        );
+        $this->assertNull($email->getHeaders()->get('In-Reply-To'));
+        $this->assertMatchesRegularExpression(
+            "/^reply\\+{$ticket->id}\\.[a-f0-9]{8}@support\\.example\\.com$/",
+            $email->getReplyTo()[0]->getAddress()
+        );
+    }
+
+    public function test_ticket_reply_notification_sets_reply_message_id_and_thread_headers(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $reply = Reply::factory()->create(['ticket_id' => $ticket->id]);
+        $user = $this->createTestUser();
+        $mail = (new TicketReplyNotification($reply))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertSame(
+            "ticket-{$ticket->id}-reply-{$reply->id}@support.example.com",
+            trim((string) $email->getHeaders()->get('Message-ID')->getId(), '<>')
+        );
+        $this->assertSame(
+            "ticket-{$ticket->id}@support.example.com",
+            trim((string) $email->getHeaders()->get('In-Reply-To')->getId(), '<>')
+        );
+        $this->assertSame(
+            "ticket-{$ticket->id}@support.example.com",
+            trim((string) $email->getHeaders()->get('References')->getId(), '<>')
+        );
+    }
+
+    public function test_sla_breach_notification_joins_ticket_thread(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $user = $this->createTestUser();
+        $mail = (new SlaBreachNotification($ticket, 'first_response'))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertSame(
+            "ticket-{$ticket->id}@support.example.com",
+            trim((string) $email->getHeaders()->get('In-Reply-To')->getId(), '<>')
+        );
+        $this->assertSame(
+            "ticket-{$ticket->id}@support.example.com",
+            trim((string) $email->getHeaders()->get('References')->getId(), '<>')
+        );
+    }
+
+    public function test_ticket_assigned_notification_joins_ticket_thread(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $user = $this->createTestUser();
+        $mail = (new TicketAssignedNotification($ticket))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertNotNull($email->getHeaders()->get('In-Reply-To'));
+    }
+
+    public function test_ticket_escalated_notification_joins_ticket_thread(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $user = $this->createTestUser();
+        $mail = (new TicketEscalatedNotification($ticket))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertNotNull($email->getHeaders()->get('In-Reply-To'));
+    }
+
+    public function test_ticket_resolved_notification_joins_ticket_thread(): void
+    {
+        $ticket = Ticket::factory()->create(['status' => TicketStatus::Resolved]);
+        $user = $this->createTestUser();
+        $mail = (new TicketResolvedNotification($ticket))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertNotNull($email->getHeaders()->get('In-Reply-To'));
+    }
+
+    public function test_ticket_status_changed_notification_joins_ticket_thread(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $user = $this->createTestUser();
+        $mail = (new TicketStatusChangedNotification(
+            $ticket,
+            TicketStatus::Open,
+            TicketStatus::InProgress
+        ))->toMail($user);
+        $email = new Email;
+
+        $this->runCallbacksOn($email, $mail);
+
+        $this->assertNotNull($email->getHeaders()->get('In-Reply-To'));
+    }
+
+    public function test_every_notification_applies_signed_reply_to(): void
+    {
+        $ticket = Ticket::factory()->create();
+        $reply = Reply::factory()->create(['ticket_id' => $ticket->id]);
+        $user = $this->createTestUser();
+
+        $cases = [
+            new NewTicketNotification($ticket),
+            new TicketReplyNotification($reply),
+            new SlaBreachNotification($ticket, 'resolution'),
+            new TicketAssignedNotification($ticket),
+            new TicketEscalatedNotification($ticket),
+            new TicketResolvedNotification($ticket),
+            new TicketStatusChangedNotification($ticket, TicketStatus::Open, TicketStatus::Resolved),
+        ];
+
+        foreach ($cases as $notification) {
+            $email = new Email;
+            $mail = $notification->toMail($user);
+            $this->runCallbacksOn($email, $mail);
+
+            $this->assertMatchesRegularExpression(
+                "/^reply\\+{$ticket->id}\\.[a-f0-9]{8}@support\\.example\\.com$/",
+                $email->getReplyTo()[0]->getAddress(),
+                'Notification '.get_class($notification).' did not apply signed Reply-To'
+            );
+        }
+    }
+}

--- a/tests/Unit/NotificationThreadingTest.php
+++ b/tests/Unit/NotificationThreadingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Escalated\Laravel\Tests\Unit;
+
+use Escalated\Laravel\Mail\NotificationThreading;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Tests\TestCase;
+use Symfony\Component\Mime\Email;
+
+/**
+ * Tests for NotificationThreading — verifies the headers every
+ * outbound notification gets when its withSymfonyMessage callback
+ * delegates to this helper.
+ */
+class NotificationThreadingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('escalated.email.domain', 'support.example.com');
+        config()->set('escalated.email.inbound_secret', 'test-secret-for-hmac');
+    }
+
+    private function ticket(int $id = 42): Ticket
+    {
+        $ticket = new Ticket;
+        $ticket->id = $id;
+
+        return $ticket;
+    }
+
+    public function test_apply_anchor_sets_ticket_root_message_id(): void
+    {
+        $message = new Email;
+        NotificationThreading::applyAnchor($message, $this->ticket());
+
+        $this->assertSame(
+            'ticket-42@support.example.com',
+            trim((string) $message->getHeaders()->get('Message-ID')->getId(), '<>')
+        );
+        // Anchor message has no In-Reply-To (it IS the anchor).
+        $this->assertNull($message->getHeaders()->get('In-Reply-To'));
+    }
+
+    public function test_apply_anchor_sets_signed_reply_to(): void
+    {
+        $message = new Email;
+        NotificationThreading::applyAnchor($message, $this->ticket());
+
+        $replyTo = $message->getReplyTo();
+        $this->assertCount(1, $replyTo);
+        $this->assertMatchesRegularExpression(
+            '/^reply\+42\.[a-f0-9]{8}@support\.example\.com$/',
+            $replyTo[0]->getAddress()
+        );
+    }
+
+    public function test_apply_thread_sets_in_reply_to_and_references(): void
+    {
+        $message = new Email;
+        NotificationThreading::applyThread($message, $this->ticket());
+
+        $this->assertSame(
+            'ticket-42@support.example.com',
+            trim((string) $message->getHeaders()->get('In-Reply-To')->getId(), '<>')
+        );
+        $this->assertSame(
+            'ticket-42@support.example.com',
+            trim((string) $message->getHeaders()->get('References')->getId(), '<>')
+        );
+    }
+
+    public function test_apply_thread_with_reply_id_sets_own_message_id(): void
+    {
+        $message = new Email;
+        NotificationThreading::applyThread($message, $this->ticket(), 7);
+
+        $this->assertSame(
+            'ticket-42-reply-7@support.example.com',
+            trim((string) $message->getHeaders()->get('Message-ID')->getId(), '<>')
+        );
+        $this->assertSame(
+            'ticket-42@support.example.com',
+            trim((string) $message->getHeaders()->get('In-Reply-To')->getId(), '<>')
+        );
+    }
+
+    public function test_inbound_secret_blank_skips_reply_to(): void
+    {
+        config()->set('escalated.email.inbound_secret', '');
+
+        $message = new Email;
+        NotificationThreading::applyAnchor($message, $this->ticket());
+
+        $this->assertCount(0, $message->getReplyTo());
+    }
+
+    public function test_domain_falls_back_to_app_url_host(): void
+    {
+        config()->set('escalated.email.domain', '');
+        config()->set('app.url', 'https://helpdesk.mycompany.test');
+
+        $message = new Email;
+        NotificationThreading::applyAnchor($message, $this->ticket());
+
+        $this->assertStringEndsWith(
+            '@helpdesk.mycompany.test',
+            trim((string) $message->getHeaders()->get('Message-ID')->getId(), '<>')
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Wires the `MessageIdUtil` helpers (added in #68) into every Laravel notification so outbound ticket emails carry canonical RFC 5322 threading headers + signed Reply-To.

## Mechanism

New `NotificationThreading` helper with two static entry points:

- `applyAnchor(\$message, \$ticket)` — sets `Message-ID = <ticket-{id}@{domain}>`. Used by `NewTicketNotification` (the thread anchor).
- `applyThread(\$message, \$ticket, \$replyId = null)` — sets `In-Reply-To` + `References` pointing at the ticket root. When `\$replyId` is non-null, also sets own `Message-ID = <ticket-{id}-reply-{replyId}@{domain}>`. Used by all other notifications.

Both methods apply a signed `Reply-To = reply+{id}.{hmac8}@{domain}` when `escalated.email.inbound_secret` is configured.

## Config

New `config/escalated.php` block:

```php
'email' => [
    'domain' => env('ESCALATED_EMAIL_DOMAIN'),           // fallback: APP_URL host, then escalated.dev
    'inbound_secret' => env('ESCALATED_EMAIL_INBOUND_SECRET', ''),  // empty → Reply-To skipped
],
```

## Notifications refactored

| Notification | Before | After |
|---|---|---|
| `NewTicketNotification` | inline `ticket-{id}@{domain}` → Message-ID | `NotificationThreading::applyAnchor` |
| `TicketReplyNotification` | inline → In-Reply-To + References | `applyThread(..., \$replyId)` |
| `SlaBreachNotification` | inline → In-Reply-To + References | `applyThread(...)` |
| `TicketAssignedNotification` | inline → In-Reply-To + References | `applyThread(...)` |
| `TicketEscalatedNotification` | inline → In-Reply-To + References | `applyThread(...)` |
| `TicketResolvedNotification` | inline → In-Reply-To + References | `applyThread(...)` |
| `TicketStatusChangedNotification` | inline → In-Reply-To + References | `applyThread(...)` |

Removes 7 copies of the inline `parse_url(config('app.url'))` + threadId-building code.

## Dependencies

- **Stacked on #68** (`feat/email-message-id`). Will rebase onto `main` once #68 merges.

## Test plan

- [x] 6 unit tests covering the anchor / thread / reply-with-id / blank-secret / domain-fallback paths using a real Symfony Mime Email
- [ ] CI green (won't trigger against stacked base until rebased)