### PR TITLE
fix(widget): honor guest_policy_mode on public ticket creation

### DIFF
--- a/src/Http/Controllers/WidgetController.php
+++ b/src/Http/Controllers/WidgetController.php
@@ -115,18 +115,50 @@ class WidgetController extends Controller
         // across all their tickets (Pattern B).
         $contact = Contact::findOrCreateByEmail($validated['email'], $validated['name']);
 
-        $ticket = Ticket::create([
-            'guest_name' => $validated['name'],
-            'guest_email' => $validated['email'],
-            'guest_token' => Str::random(64),
-            'contact_id' => $contact->id,
+        $attrs = [
             'subject' => $validated['subject'],
             'description' => $validated['description'],
             'status' => TicketStatus::Open,
             'priority' => TicketPriority::from(config('escalated.default_priority', 'medium')),
             'channel' => 'widget',
             'department_id' => $validated['department_id'] ?? null,
-        ]);
+            'contact_id' => $contact->id,
+        ];
+
+        // Apply the admin-configured guest policy. Persisted by
+        // PublicTicketsSettingsController under three keys in the
+        // EscalatedSettings table. Modes:
+        //   - unassigned (default): write guest_name / guest_email /
+        //     guest_token, leave requester_* null.
+        //   - guest_user: route to a pre-created host-app user via
+        //     requester_id + requester_type. Still records guest_name/
+        //     guest_email so agents can see who submitted.
+        //   - prompt_signup: same ticket-create path as unassigned;
+        //     signup-invite emission is a listener-level follow-up.
+        $mode = EscalatedSettings::get('guest_policy_mode', 'unassigned');
+
+        if ($mode === 'guest_user') {
+            $guestUserId = (int) EscalatedSettings::get('guest_policy_user_id', 0);
+            if ($guestUserId > 0) {
+                $attrs['requester_type'] = config('escalated.user_model', 'App\\Models\\User');
+                $attrs['requester_id'] = $guestUserId;
+                $attrs['guest_name'] = $validated['name'];
+                $attrs['guest_email'] = $validated['email'];
+            } else {
+                // Misconfigured guest_user mode (no/zero user id):
+                // fall through to unassigned behavior so submissions
+                // still succeed instead of 500ing.
+                $attrs['guest_name'] = $validated['name'];
+                $attrs['guest_email'] = $validated['email'];
+                $attrs['guest_token'] = Str::random(64);
+            }
+        } else {
+            $attrs['guest_name'] = $validated['name'];
+            $attrs['guest_email'] = $validated['email'];
+            $attrs['guest_token'] = Str::random(64);
+        }
+
+        $ticket = Ticket::create($attrs);
 
         return response()->json([
             'message' => 'Ticket created successfully.',

--- a/tests/Feature/WidgetControllerTest.php
+++ b/tests/Feature/WidgetControllerTest.php
@@ -222,3 +222,87 @@ it('returns 403 for all endpoints when widget disabled', function () {
         'description' => 'Test',
     ])->assertStatus(403);
 });
+
+// --- Guest policy integration with widget ticket creation ---
+
+it('respects guest_policy unassigned mode (default) writing guest_* fields', function () {
+    EscalatedSettings::set('widget_enabled', '1');
+    EscalatedSettings::set('guest_tickets_enabled', '1');
+    EscalatedSettings::set('guest_policy_mode', 'unassigned');
+
+    $response = $this->postJson(route('escalated.widget.tickets.store'), [
+        'name' => 'Alice',
+        'email' => 'alice@example.com',
+        'subject' => 'Hello',
+        'description' => 'Question.',
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('escalated_tickets', [
+        'guest_email' => 'alice@example.com',
+        'requester_id' => null,
+        'requester_type' => null,
+    ]);
+});
+
+it('respects guest_policy guest_user mode routing to the configured host user', function () {
+    EscalatedSettings::set('widget_enabled', '1');
+    EscalatedSettings::set('guest_tickets_enabled', '1');
+    EscalatedSettings::set('guest_policy_mode', 'guest_user');
+    EscalatedSettings::set('guest_policy_user_id', '42');
+
+    $response = $this->postJson(route('escalated.widget.tickets.store'), [
+        'name' => 'Bob',
+        'email' => 'bob@example.com',
+        'subject' => 'Hi',
+        'description' => 'Another question.',
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('escalated_tickets', [
+        'requester_id' => 42,
+        'requester_type' => config('escalated.user_model', 'App\\Models\\User'),
+        'guest_email' => 'bob@example.com',
+    ]);
+});
+
+it('falls through to unassigned behavior when guest_user mode has no user id', function () {
+    EscalatedSettings::set('widget_enabled', '1');
+    EscalatedSettings::set('guest_tickets_enabled', '1');
+    EscalatedSettings::set('guest_policy_mode', 'guest_user');
+    // user_id intentionally missing / zero
+    EscalatedSettings::set('guest_policy_user_id', '');
+
+    $response = $this->postJson(route('escalated.widget.tickets.store'), [
+        'name' => 'Charlie',
+        'email' => 'charlie@example.com',
+        'subject' => 'Help',
+        'description' => 'Guest user fallback scenario.',
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('escalated_tickets', [
+        'guest_email' => 'charlie@example.com',
+        'requester_id' => null,
+        'requester_type' => null,
+    ]);
+});
+
+it('prompt_signup mode uses unassigned ticket-creation path (signup invite is separate)', function () {
+    EscalatedSettings::set('widget_enabled', '1');
+    EscalatedSettings::set('guest_tickets_enabled', '1');
+    EscalatedSettings::set('guest_policy_mode', 'prompt_signup');
+
+    $response = $this->postJson(route('escalated.widget.tickets.store'), [
+        'name' => 'Dana',
+        'email' => 'dana@example.com',
+        'subject' => 'Hi',
+        'description' => 'Signup-prompt scenario.',
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('escalated_tickets', [
+        'guest_email' => 'dana@example.com',
+        'requester_id' => null,
+    ]);
+});


### PR DESCRIPTION
## Summary

Fixes a real behavioral gap: the admin settings page at \`Admin → Settings → Public tickets\` (\`PublicTicketsSettingsController\` from #71) has been persisting \`guest_policy_mode\` / \`guest_policy_user_id\` / \`guest_policy_signup_url_template\` to \`EscalatedSettings\`, but \`WidgetController::createTicket\` wrote \`guest_name\` / \`guest_email\` / \`guest_token\` unconditionally regardless of mode — **so the settings page had zero behavioral effect**.

I caught this while auditing the NestJS reference's widget↔settings wiring against the Laravel behavior for the public-tickets docs page ([escalated-docs#10](https://github.com/escalated-dev/escalated-docs/pull/10)). The NestJS reference doesn't have this bug because its widget controller reads \`settingsService.getTyped('guest_policy')\`; Laravel's widget controller simply didn't read any guest-policy setting.

## What changed

\`WidgetController::createTicket\` now branches on \`guest_policy_mode\`:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | Existing behavior — \`guest_*\` fields set, \`requester_*\` null. |
| \`guest_user\` | Route to the configured host user: \`requester_id = guest_policy_user_id\`, \`requester_type = config('escalated.user_model')\`. Still records \`guest_name\` / \`guest_email\` so agents see who submitted — the shared user is the authorization anchor, not the identity. |
| \`prompt_signup\` | Same ticket-creation path as unassigned for now. Signup-invite event emission is a listener-level follow-up that needs a \`TicketSignupInviteEvent\` class added to the plugin first. |

Misconfigured \`guest_user\` mode (zero or missing \`guest_policy_user_id\`) falls through to unassigned behavior so bad admin input can't 500 the public submission endpoint.

## Test plan

- [x] 4 new Pest cases in \`WidgetControllerTest\`: unassigned mode (regression test for the default path), \`guest_user\` with valid user id, \`guest_user\` with missing user id fallback, \`prompt_signup\` path.
- [x] Full \`WidgetControllerTest\` suite: 13/13 green.
- [x] \`./vendor/bin/pint --test\` on modified files: clean.
- [ ] Reviewer: confirm the \`requester_type\` value format matches what existing agent-auth flows expect (I used \`config('escalated.user_model')\` which defaults to \`App\Models\User\`; polymorphic lookups elsewhere in the codebase use the same config key).

## Follow-ups outside this PR

- The same bug likely affects the other legacy host-framework plugins that use Pattern A (inline guest fields) — Rails / Django / Adonis / WordPress. Each needs an equivalent patch against its own widget controller.
- Signup-invite emission for \`prompt_signup\` mode — needs a \`TicketSignupInviteEvent\` + listener added to the plugin.