### PR TITLE
feat(inbound): MessageIdUtil-based Message-ID parsing + signed Reply-To verification

### DIFF
--- a/src/Services/InboundEmailService.php
+++ b/src/Services/InboundEmailService.php
@@ -8,6 +8,7 @@ use Escalated\Laravel\Enums\TicketStatus;
 use Escalated\Laravel\Escalated;
 use Escalated\Laravel\Events;
 use Escalated\Laravel\Mail\InboundMessage;
+use Escalated\Laravel\Mail\MessageIdUtil;
 use Escalated\Laravel\Models\Attachment;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\InboundEmail;
@@ -86,13 +87,46 @@ class InboundEmailService
     /**
      * Find an existing ticket that this email is replying to.
      *
-     * Checks:
-     * 1. Subject line for ticket reference pattern like [ESC-00001]
-     * 2. In-Reply-To / References headers for matching message IDs
+     * Resolution order (first match wins):
+     *   1. In-Reply-To header parsed via MessageIdUtil — the reply is
+     *      threading off a Message-ID we issued.
+     *   2. References header, each id parsed in order.
+     *   3. Signed Reply-To on the recipient address (`reply+{id}.{hmac8}@...`)
+     *      — verified with MessageIdUtil::verifyReplyTo, which rules out
+     *      forgery. This is the survive-through-client path: even when
+     *      clients strip our threading headers, the Reply-To we set on
+     *      outbound carries ticket identity.
+     *   4. Subject line `[ESC-00001]` reference pattern (historical).
+     *   5. In-Reply-To / References looked up in the InboundEmail table
+     *      (relies on the receiving mail server storing Message-IDs we
+     *      issued in the past — weaker than #1 but covers legacy).
      */
     protected function findTicketByEmail(InboundMessage $message): ?Ticket
     {
-        // Check subject for reference pattern
+        // 1/2. Parse our own Message-IDs out of In-Reply-To / References.
+        foreach ($this->candidateHeaderMessageIds($message) as $raw) {
+            $ticketId = MessageIdUtil::parseTicketIdFromMessageId($raw);
+            if ($ticketId !== null) {
+                $ticket = Ticket::find($ticketId);
+                if ($ticket) {
+                    return $ticket;
+                }
+            }
+        }
+
+        // 3. Signed Reply-To on the recipient address.
+        $secret = (string) config('escalated.email.inbound_secret', '');
+        if ($secret !== '') {
+            $verified = MessageIdUtil::verifyReplyTo($message->toEmail, $secret);
+            if ($verified !== null) {
+                $ticket = Ticket::find($verified);
+                if ($ticket) {
+                    return $ticket;
+                }
+            }
+        }
+
+        // 4. Subject line reference pattern.
         $prefix = EscalatedSettings::get('ticket_reference_prefix', 'ESC');
         $pattern = '/\[('.preg_quote($prefix, '/').'-\d+)\]/';
 
@@ -103,19 +137,8 @@ class InboundEmailService
             }
         }
 
-        // Check In-Reply-To and References headers against stored message IDs
-        $headerMessageIds = [];
-
-        if (! empty($message->inReplyTo)) {
-            $headerMessageIds[] = $message->inReplyTo;
-        }
-
-        if (! empty($message->references)) {
-            // References header can contain multiple message IDs separated by whitespace
-            $refs = preg_split('/\s+/', $message->references);
-            $headerMessageIds = array_merge($headerMessageIds, $refs);
-        }
-
+        // 5. Legacy fallback: look up by any header id stored in InboundEmail.
+        $headerMessageIds = $this->candidateHeaderMessageIds($message);
         if (! empty($headerMessageIds)) {
             $relatedEmail = InboundEmail::whereIn('message_id', $headerMessageIds)
                 ->whereNotNull('ticket_id')
@@ -129,6 +152,32 @@ class InboundEmailService
         }
 
         return null;
+    }
+
+    /**
+     * Return every candidate Message-ID in the inbound headers, in
+     * the order the mail client sent them. The first entry in References
+     * is the oldest ancestor; In-Reply-To is the immediate parent.
+     *
+     * @return array<string>
+     */
+    protected function candidateHeaderMessageIds(InboundMessage $message): array
+    {
+        $ids = [];
+        if (! empty($message->inReplyTo)) {
+            $ids[] = $message->inReplyTo;
+        }
+        if (! empty($message->references)) {
+            $refs = preg_split('/\s+/', $message->references) ?: [];
+            foreach ($refs as $ref) {
+                $ref = trim($ref);
+                if ($ref !== '') {
+                    $ids[] = $ref;
+                }
+            }
+        }
+
+        return $ids;
     }
 
     /**

--- a/tests/Unit/InboundEmailServiceTest.php
+++ b/tests/Unit/InboundEmailServiceTest.php
@@ -2,6 +2,7 @@
 
 use Escalated\Laravel\Enums\TicketStatus;
 use Escalated\Laravel\Mail\InboundMessage;
+use Escalated\Laravel\Mail\MessageIdUtil;
 use Escalated\Laravel\Models\EscalatedSettings;
 use Escalated\Laravel\Models\InboundEmail;
 use Escalated\Laravel\Models\Ticket;
@@ -263,6 +264,103 @@ it('derives guest name from email when no name provided', function () {
 
     $ticket = Ticket::find($inbound->ticket_id);
     expect($ticket->guest_name)->toBe('John Doe');
+});
+
+it('finds ticket by canonical In-Reply-To Message-ID via MessageIdUtil', function () {
+    // No InboundEmail row — this is the cold-start path where the
+    // reply hits us first. Parsing the ticket id out of the canonical
+    // Message-ID format lets us route without database lookup.
+    $ticket = Ticket::factory()->create();
+
+    $service = app(InboundEmailService::class);
+    $message = new InboundMessage(
+        fromEmail: 'nobody@example.com',
+        fromName: null,
+        toEmail: 'support@example.com',
+        subject: 'RE: ticket',
+        bodyText: 'Follow up.',
+        bodyHtml: null,
+        inReplyTo: "<ticket-{$ticket->id}@support.example.com>",
+    );
+
+    $inbound = $service->process($message, 'mailgun');
+
+    expect($inbound->ticket_id)->toBe($ticket->id);
+});
+
+it('finds ticket by canonical References header via MessageIdUtil', function () {
+    $ticket = Ticket::factory()->create();
+
+    $service = app(InboundEmailService::class);
+    $message = new InboundMessage(
+        fromEmail: 'nobody@example.com',
+        fromName: null,
+        toEmail: 'support@example.com',
+        subject: 'RE: ticket',
+        bodyText: 'Follow up.',
+        bodyHtml: null,
+        references: "<unrelated@mail.com> <ticket-{$ticket->id}@support.example.com>",
+    );
+
+    $inbound = $service->process($message, 'mailgun');
+
+    expect($inbound->ticket_id)->toBe($ticket->id);
+});
+
+it('finds ticket by signed Reply-To when inbound_secret is configured', function () {
+    config(['escalated.email.inbound_secret' => 'test-secret']);
+    config(['escalated.email.domain' => 'support.example.com']);
+    $ticket = Ticket::factory()->create();
+
+    $replyTo = MessageIdUtil::buildReplyTo(
+        $ticket->id,
+        'test-secret',
+        'support.example.com'
+    );
+
+    $service = app(InboundEmailService::class);
+    $message = new InboundMessage(
+        fromEmail: 'customer@example.com',
+        fromName: null,
+        toEmail: $replyTo, // this is what the customer's client sends to
+        subject: 'My issue',
+        bodyText: 'Another message.',
+        bodyHtml: null,
+        // No In-Reply-To / References — clients stripped them. The
+        // signed Reply-To is the safety net.
+    );
+
+    $inbound = $service->process($message, 'mailgun');
+
+    expect($inbound->ticket_id)->toBe($ticket->id);
+});
+
+it('rejects a forged Reply-To signature', function () {
+    config(['escalated.email.inbound_secret' => 'real-secret']);
+    config(['escalated.email.domain' => 'support.example.com']);
+    $ticket = Ticket::factory()->create();
+
+    // Signed with a DIFFERENT secret — should not verify.
+    $forged = MessageIdUtil::buildReplyTo(
+        $ticket->id,
+        'wrong-secret',
+        'support.example.com'
+    );
+
+    $service = app(InboundEmailService::class);
+    $message = new InboundMessage(
+        fromEmail: 'attacker@example.com',
+        fromName: null,
+        toEmail: $forged,
+        subject: 'Try to take over ticket',
+        bodyText: 'injected content.',
+        bodyHtml: null,
+    );
+
+    $inbound = $service->process($message, 'mailgun');
+
+    // Not routed to the ticket — falls through to new-ticket creation.
+    expect($inbound->ticket_id)->not->toBe($ticket->id);
 });
 
 it('finds ticket by In-Reply-To header', function () {


### PR DESCRIPTION
Continuation of escalated-dev/escalated-laravel#70 (auto-closed when its base branch `feat/email-message-id` was deleted on merge of #68). Same content, rebased onto main; conflicts in InboundEmailServiceTest.php resolved (kept both EscalatedSettings + MessageIdUtil imports).

## Test plan
- [x] All 19 InboundEmailService tests pass