### PR TITLE
chore(deps): host-app Vite 8 + Tailwind 4

### DIFF
--- a/docker/host-app/package.json
+++ b/docker/host-app/package.json
@@ -10,13 +10,13 @@
     },
     "devDependencies": {
         "@inertiajs/vue3": "^2.0.0",
-        "@vitejs/plugin-vue": "^5.0.5",
-        "autoprefixer": "^10.4.20",
+        "@tailwindcss/postcss": "^4.2.4",
+        "@vitejs/plugin-vue": "^6.0.6",
         "axios": "^1.7.9",
-        "laravel-vite-plugin": "^1.0.0",
+        "laravel-vite-plugin": "^3.1.0",
         "postcss": "^8.4.49",
-        "tailwindcss": "^3.4.17",
-        "vite": "^6.0.0",
+        "tailwindcss": "^4.2.4",
+        "vite": "^8.0.10",
         "vue": "^3.5.13"
     }
 }

--- a/docker/host-app/postcss.config.js
+++ b/docker/host-app/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
     plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
+        '@tailwindcss/postcss': {},
     },
 };

--- a/docker/host-app/resources/css/app.css
+++ b/docker/host-app/resources/css/app.css
@@ -1,3 +1,2 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@config "../../tailwind.config.js";


### PR DESCRIPTION
## Summary

Bundles four open Dependabot PRs into a single coordinated upgrade for the `docker/host-app` frontend toolchain. The Vite-set and Tailwind 4 migration are landed together because their peer requirements interlock (`laravel-vite-plugin@3` requires Vite 8; `@vitejs/plugin-vue@6` requires Vite 7+).

Bundled PRs:
- #80 @vitejs/plugin-vue 5 -> 6
- #81 laravel-vite-plugin 1 -> 3
- #82 tailwindcss 3 -> 4
- #83 vite 6 -> 8

## Changes

- `docker/host-app/package.json`: bump vite, @vitejs/plugin-vue, laravel-vite-plugin, tailwindcss; add @tailwindcss/postcss; drop autoprefixer (Tailwind v4 handles vendor prefixing internally).
- `docker/host-app/postcss.config.js`: swap `tailwindcss` plugin for `@tailwindcss/postcss`; drop `autoprefixer`.
- `docker/host-app/resources/css/app.css`: replace `@tailwind base/components/utilities` directives with `@import "tailwindcss"`; reference legacy JS config via `@config "../../tailwind.config.js"` (preserves existing `content` paths including `@escalated-dev/escalated`).

`tailwind.config.js` is unchanged and still loaded via `@config`.
`resources/js/app.js` import of `resolvePageComponent` from `laravel-vite-plugin/inertia-helpers` continues to work in v3.1.0.

## Test plan

- [x] `npm install` clean (no ERESOLVE)
- [x] `npm run build` succeeds; emits `app-*.css` containing the v4.2.4 Tailwind layer and ~270kB main JS bundle
- [ ] CI green