### PR TITLE
feat(i18n): consume central translations from escalated-dev/locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Consume translation strings from the shared `escalated-dev/locale` Composer package so wording stays consistent across every Escalated host plugin. The `EscalatedServiceProvider` now stitches three layers under the `escalated` namespace: the central package (canonical), `lang/vendor/escalated/` in this repository (Laravel-specific overrides), and the host app's `lang/vendor/escalated/` (consumer overrides via `php artisan vendor:publish --tag=escalated-lang`). The package's own `resources/lang/` is retained as a fallback for environments where the central package has not yet been composer-installed.
+
 ## [1.2.1] - 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -260,7 +260,34 @@ php artisan vendor:publish --tag=escalated-config
 
 # Database migrations
 php artisan vendor:publish --tag=escalated-migrations
+
+# Translations (sourced from the central escalated-dev/locale package)
+php artisan vendor:publish --tag=escalated-lang
 ```
+
+## Translations
+
+Translation strings for the `escalated` namespace are sourced from the
+shared [`escalated-dev/locale`](https://github.com/escalated-dev/escalated-locale)
+Composer package, which is consumed by every Escalated host plugin
+(Laravel, Rails, NestJS, Django, …) so wording stays consistent across
+backends.
+
+The `EscalatedServiceProvider` wires three layers, lowest to highest
+precedence:
+
+1. **Central package** — `vendor/escalated-dev/locale/locales/{locale}/...`
+   The canonical source.
+2. **Plugin-shipped overrides** — `lang/vendor/escalated/{locale}/...` in
+   this repository, for Laravel-specific divergences.
+3. **Host-app overrides** — `{app}/lang/vendor/escalated/{locale}/...`,
+   populated via `php artisan vendor:publish --tag=escalated-lang`. Apps
+   edit those files to brand or relocalize Escalated.
+
+Each layer is merged on top of the previous one with
+`array_replace_recursive` (PHP groups) and `array_merge` (JSON), so a
+layer only needs to define the keys it changes. See
+[`lang/README.md`](lang/README.md) for details.
 
 ## Scheduling
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "library",
     "require": {
         "php": "^8.2",
+        "escalated-dev/locale": "^0.1.0",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
         "inertiajs/inertia-laravel": "^2.0|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,12 @@
     "keywords": ["laravel", "support", "tickets", "helpdesk", "customer-support"],
     "license": "MIT",
     "type": "library",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/escalated-dev/escalated-locale"
+        }
+    ],
     "require": {
         "php": "^8.2",
         "escalated-dev/locale": "^0.1.0",

--- a/lang/README.md
+++ b/lang/README.md
@@ -1,0 +1,59 @@
+# Plugin-shipped translation overrides
+
+This directory holds the **plugin-shipped overrides** layer of the
+`escalated` translation namespace.
+
+## Resolution order
+
+Translations under the `escalated` namespace are stitched together at runtime
+by `EscalatedServiceProvider::registerTranslations()`. From lowest to highest
+precedence:
+
+1. **Central package** — `vendor/escalated-dev/locale/locales/{locale}/...`
+   The canonical source of every translation, shared across all Escalated
+   host plugins (Laravel, Rails, NestJS, Django, etc.). Maintained in the
+   [`escalated-dev/escalated-locale`](https://github.com/escalated-dev/escalated-locale)
+   repository.
+2. **Plugin-shipped overrides (this directory)** — `lang/vendor/escalated/{locale}/{group}.php`
+   and `lang/vendor/escalated/{locale}.json`. Use this for Laravel-specific
+   strings that diverge from the central package — e.g. framework-specific
+   error wording, command output, or Artisan-only flows.
+3. **Host-app overrides** — `{app}/lang/vendor/escalated/{locale}/...` in the
+   consuming application. Populated via:
+   ```sh
+   php artisan vendor:publish --tag=escalated-lang
+   ```
+   Apps edit those files to brand or localize Escalated for their own
+   product.
+
+Each layer is merged on top of the previous one with
+`array_replace_recursive` (PHP groups) and `array_merge` (JSON), so a layer
+only needs to define the keys it changes.
+
+## File layout
+
+```
+lang/
+  vendor/
+    escalated/
+      en/
+        messages.php       <- overrides messages.php from central package
+        notifications.php
+      en.json              <- overrides en.json from central package
+      fr/
+        ...
+```
+
+The `lang/vendor/escalated/` path is Laravel's standard
+[published-vendor-translations](https://laravel.com/docs/localization#overriding-package-language-files)
+convention. The framework's `Illuminate\Translation\FileLoader` discovers
+files there automatically once the parent path is registered on the loader,
+which the service provider does in
+`registerTranslations()`.
+
+## Don't put new translations here
+
+This directory is for **overrides only**. New translations should land in
+[`escalated-dev/escalated-locale`](https://github.com/escalated-dev/escalated-locale)
+so every host plugin picks them up — that is the whole point of the
+central package.

--- a/src/EscalatedServiceProvider.php
+++ b/src/EscalatedServiceProvider.php
@@ -82,7 +82,7 @@ class EscalatedServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'escalated');
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'escalated');
+        $this->registerTranslations();
 
         $this->registerPublishing();
         $this->registerCoreRoutes();
@@ -104,6 +104,47 @@ class EscalatedServiceProvider extends ServiceProvider
     {
         return config('escalated.ui.enabled', true)
             && class_exists(Inertia::class);
+    }
+
+    /**
+     * Register the `escalated` translation namespace.
+     *
+     * Resolution order (lowest to highest precedence):
+     *   1. Central package at vendor/escalated-dev/locale/locales — canonical source.
+     *   2. Plugin-shipped overrides at lang/vendor/escalated/{locale}/{group}.php
+     *      (Laravel's namespace-override convention; loaded automatically by
+     *      \Illuminate\Translation\FileLoader::loadNamespaceOverrides via addPath).
+     *   3. Host-app overrides at the application's lang/vendor/escalated/{locale}/...
+     *      directory — already supported by Laravel because the framework registers
+     *      the app's lang path on the file loader by default. Apps populate this via
+     *      `php artisan vendor:publish --tag=escalated-lang`.
+     *
+     * The pre-1.3 behavior loaded everything from `resources/lang` of this package.
+     * That directory is retained as a fallback so dev environments keep working
+     * before `composer install` has pulled the central package.
+     */
+    protected function registerTranslations(): void
+    {
+        $centralPath = base_path('vendor/escalated-dev/locale/locales');
+        $fallbackPath = __DIR__.'/../resources/lang';
+
+        $base = is_dir($centralPath) ? $centralPath : $fallbackPath;
+
+        $this->loadTranslationsFrom($base, 'escalated');
+        $this->loadJsonTranslationsFrom($base);
+
+        // Plugin-shipped overrides. Files live under lang/vendor/escalated/{locale}/...
+        // following Laravel's published-vendor-translations convention so the framework
+        // discovers them through FileLoader::loadNamespaceOverrides().
+        $pluginOverrideRoot = __DIR__.'/../lang';
+
+        if (is_dir($pluginOverrideRoot.'/vendor/escalated')) {
+            $this->callAfterResolving('translator', function ($translator) use ($pluginOverrideRoot) {
+                $loader = $translator->getLoader();
+                $loader->addPath($pluginOverrideRoot);
+                $loader->addJsonPath($pluginOverrideRoot.'/vendor/escalated');
+            });
+        }
     }
 
     protected function registerPublishing(): void
@@ -128,8 +169,11 @@ class EscalatedServiceProvider extends ServiceProvider
             __DIR__.'/../resources/views' => resource_path('views/vendor/escalated'),
         ], 'escalated-views');
 
+        $centralPath = base_path('vendor/escalated-dev/locale/locales');
+        $langSource = is_dir($centralPath) ? $centralPath : __DIR__.'/../resources/lang';
+
         $this->publishes([
-            __DIR__.'/../resources/lang' => $this->app->langPath('vendor/escalated'),
+            $langSource => $this->app->langPath('vendor/escalated'),
         ], 'escalated-lang');
     }
 


### PR DESCRIPTION
## Summary

Wire the `escalated` translation namespace to read its canonical strings from the shared [`escalated-dev/locale`](https://github.com/escalated-dev/escalated-locale) Composer package, layered with plugin-local and host-app overrides.

The central package is the single source of truth for translation strings across every Escalated host plugin (Laravel, Rails, NestJS, Django, …). Pulling Laravel onto it unblocks the cross-plugin string parity work.

## Wiring

`EscalatedServiceProvider::registerTranslations()` stitches three layers under the `escalated` namespace, lowest to highest precedence:

1. **Central package** — `vendor/escalated-dev/locale/locales/{locale}/{group}.php` and `vendor/escalated-dev/locale/locales/{locale}.json`. Registered as the namespace hint via `loadTranslationsFrom()` / `loadJsonTranslationsFrom()`.
2. **Plugin-shipped overrides** — `lang/vendor/escalated/{locale}/{group}.php` in this repository (intentionally Laravel-canonical published-vendor-translations layout). The provider registers the parent `lang/` directory on the translator's `FileLoader`, so Laravel's built-in `FileLoader::loadNamespaceOverrides()` picks the files up via `array_replace_recursive` with no further wiring.
3. **Host-app overrides** — `{app}/lang/vendor/escalated/{locale}/...` populated by `php artisan vendor:publish --tag=escalated-lang`. Discovered automatically because the framework registers the app's lang path on the loader by default.

The publish source for `escalated-lang` is also switched to the central package (with a fallback to `resources/lang`) so apps that publish vendor translations get the canonical copy, not a stale plugin-bundled one.

`resources/lang/` of this package is retained as a **dev fallback**: if the central package has not yet been composer-installed, the provider seamlessly falls back to it. That keeps local dev and the existing test suite working until `escalated-dev/locale` v0.1.0 lands.

## Files changed

- `composer.json` — add `escalated-dev/locale: ^0.1.0` to `require`
- `src/EscalatedServiceProvider.php` — extract `registerTranslations()`, switch `escalated-lang` publish source
- `lang/vendor/escalated/.gitkeep` + `lang/README.md` — scaffold plugin-shipped overrides directory and document the layout
- `README.md` — new **Translations** section explaining the override chain, plus the `escalated-lang` tag in **Publishing Assets**
- `CHANGELOG.md` — `[Unreleased]` entry

No translation content is added or modified — strings continue to live in the upstream package and the existing `resources/lang/` fallback.

## Blocked on escalated-dev/escalated-locale v0.1.0 publish

The `escalated-dev/locale` package is being bootstrapped in [`escalated-dev/escalated-locale`](https://github.com/escalated-dev/escalated-locale) and is **not yet published** to Packagist. CI will fail at `composer install` with a "could not find a matching version of package escalated-dev/locale" error until v0.1.0 ships. **That is expected**, which is why this PR is opened as a draft. It will be marked ready-for-review once the central package is published.

## Test plan

- [ ] After `escalated-dev/locale` v0.1.0 is published, run `composer update escalated-dev/locale` locally and confirm CI goes green.
- [ ] Verify `__('escalated::messages.<key>')` resolves from `vendor/escalated-dev/locale/locales/en/messages.php` once installed.
- [ ] Drop a stub at `lang/vendor/escalated/en/messages.php` defining one key and confirm it overrides the central package's value.
- [ ] Run `php artisan vendor:publish --tag=escalated-lang` in a host app and confirm files land in `lang/vendor/escalated/` from the central package source.
- [ ] Confirm fallback path: temporarily remove `vendor/escalated-dev/locale/`, reboot the app, and confirm strings still resolve from this package's `resources/lang/`.