### PR TITLE
Resolve Unique Index name too long error

### DIFF
--- a/database/migrations/2026_02_24_000008_create_escalated_ticket_links_table.php
+++ b/database/migrations/2026_02_24_000008_create_escalated_ticket_links_table.php
@@ -27,7 +27,7 @@ return new class extends Migration
                 ->on($prefix.'tickets')
                 ->cascadeOnDelete();
 
-            $table->unique(['parent_ticket_id', 'child_ticket_id', 'link_type']);
+            $table->unique(['parent_ticket_id', 'child_ticket_id', 'link_type'], 'parent_child_type_unique');
         });
 
         Schema::table($prefix.'tickets', function (Blueprint $table) {


### PR DESCRIPTION
Resolve the following SQL error

Syntax error or access violation: 1059 Identifier name 'escalated_ticket_links_parent_ticket_id_child_ticket_id_link_type_unique' is too long