### PR TITLE
fix(migration): assign explicit name to delayed_actions index

### DIFF
--- a/database/migrations/2026_04_07_100003_create_escalated_delayed_actions_table.php
+++ b/database/migrations/2026_04_07_100003_create_escalated_delayed_actions_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->boolean('cancelled')->default(false);
             $table->timestamps();
 
-            $table->index(['execute_at', 'executed', 'cancelled']);
+            $table->index(['execute_at', 'executed', 'cancelled'], 'delayed_actions_exec_idx');
             $table->index('ticket_id');
         });
     }


### PR DESCRIPTION
## Summary

Follow-up to #86. Pre-empts the same `Identifier name too long` SQL error in the `delayed_actions` migration.

The auto-generated index name is `[prefix]delayed_actions_execute_at_executed_cancelled_index` — 51 chars + prefix length. With the default `escalated_` prefix that's 61 chars (fits), but anyone configuring `escalated.table_prefix` to a value longer than 13 characters hits MySQL's 64-char identifier limit.

Assigning an explicit short name (`delayed_actions_exec_idx`, 24 chars) makes the migration safe under any prefix length.

## Backwards compatibility

Same logic as #86 — Laravel runs each migration once and tracks it in the `migrations` table. Two cases:

1. **Migration already succeeded** (default prefix or short prefix): the long auto-generated index lives in the user's schema. The migration won't re-run, so the new explicit name only matters for fresh installs. No conflict.
2. **Migration failed** (long custom prefix on MySQL/PostgreSQL): nothing was created, no row in the `migrations` table. The fix unblocks them.

No existing install can be broken by this change.

## Test plan

- [x] Tests pass on SQLite (default CI matrix) — SQLite has no identifier limit, so it never exposed the bug
- [ ] Manually verify on MySQL with a custom 20-char prefix that fresh `php artisan migrate` succeeds
