### PR TITLE
fix(install): surface migrate / seed errors instead of swallowing them

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -148,41 +148,52 @@ class InstallCommand extends Command
 
     protected function runMigrations(): bool
     {
-        $success = false;
+        // Print output directly (no `task` component / no `callSilently`) so
+        // the user sees the actual SQL error if a migration fails. Swallowing
+        // it produces a useless "FAIL" with no diagnosis — see issue #88.
+        $this->components->info(__('escalated::commands.install.runningMigrations'));
+        try {
+            $exit = $this->call('migrate', ['--force' => true]);
+        } catch (\Throwable $e) {
+            $this->components->error('migrate threw: '.$e->getMessage());
 
-        $this->components->task(__('escalated::commands.install.runningMigrations'), function () use (&$success) {
-            try {
-                $exit = $this->callSilently('migrate', ['--force' => true]);
-                $success = $exit === 0;
-            } catch (\Throwable) {
-                $success = false;
-            }
+            return false;
+        }
 
-            return $success;
-        });
+        if ($exit !== 0) {
+            $this->components->error(
+                'migrate exited with code '.$exit.'. The error is shown above. '
+                .'Run `php artisan migrate -vvv` to see the full PDO/SQL detail, '
+                .'then re-run this command.'
+            );
 
-        return $success;
+            return false;
+        }
+
+        return true;
     }
 
     protected function seedPermissions(): bool
     {
-        $success = false;
+        $this->components->info(__('escalated::commands.install.seedingPermissions'));
+        try {
+            $exit = $this->call('db:seed', [
+                '--class' => PermissionSeeder::class,
+                '--force' => true,
+            ]);
+        } catch (\Throwable $e) {
+            $this->components->error('db:seed threw: '.$e->getMessage());
 
-        $this->components->task(__('escalated::commands.install.seedingPermissions'), function () use (&$success) {
-            try {
-                $exit = $this->callSilently('db:seed', [
-                    '--class' => PermissionSeeder::class,
-                    '--force' => true,
-                ]);
-                $success = $exit === 0;
-            } catch (\Throwable) {
-                $success = false;
-            }
+            return false;
+        }
 
-            return $success;
-        });
+        if ($exit !== 0) {
+            $this->components->error('db:seed exited with code '.$exit.'. The error is shown above.');
 
-        return $success;
+            return false;
+        }
+
+        return true;
     }
 
     protected function installNpmPackage(): void


### PR DESCRIPTION
## Summary

Issue #88 reproduced again on a fresh install — different root cause than the v1.2.3 ordering fix. The `runMigrations()` helper was using `callSilently('migrate')` wrapped in a `task` component, which swallowed the actual SQL error and just printed `FAIL` with no detail. Took a back-and-forth with the reporter to surface the real error (`errno: 150 Foreign key constraint is incorrectly formed` on `escalated_macros` against `users(id)`), which is the kind of thing the user should have seen on the first run.

This change replaces the silent task-wrapped call with a plain `$this->call('migrate', ['--force' => true])` so Laravel's own migrate output (per-migration timing, the failing migration name, the full PDO/SQL error, the stack frame) goes straight to the terminal. Same treatment for `seedPermissions()`. On non-zero exit, a clear hint to re-run with `migrate -vvv` for full PDO detail.

The real cause of #88 is being investigated separately; this PR is purely the diagnostic improvement so future reports come in with the actual error attached.

## Test plan

- [x] `pest tests/Unit/InstallCommandTest.php` — 22 passed (35 assertions)
- [ ] CI green
- [ ] Manual: trigger a deliberately failing migration (e.g. drop a referenced table mid-flow) and confirm the SQL error is now visible

Refs #88.
