### PR TITLE
fix(migrations): drop FK constraints to host users table (resolves #88)

### DIFF
--- a/database/migrations/2024_01_01_000013_create_escalated_macros_table.php
+++ b/database/migrations/2024_01_01_000013_create_escalated_macros_table.php
@@ -15,7 +15,12 @@ return new class extends Migration
             $table->string('name');
             $table->string('description')->nullable();
             $table->json('actions');
-            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            // No DB-level FK to host `users`. Host apps run on a wide range of
+            // MySQL/MariaDB configurations (MyISAM `users` table, signed bigint
+            // id from pre-Laravel-5.8 scaffolds, INT UNSIGNED from
+            // `increments()`, UUID/CHAR(36) from `HasUuids`) — any of which
+            // make MariaDB reject FK creation with errno 150. See #88.
+            $table->unsignedBigInteger('created_by')->nullable();
             $table->boolean('is_shared')->default(true);
             $table->integer('order')->default(0);
             $table->timestamps();

--- a/database/migrations/2024_01_01_000014_create_escalated_ticket_followers_table.php
+++ b/database/migrations/2024_01_01_000014_create_escalated_ticket_followers_table.php
@@ -12,7 +12,8 @@ return new class extends Migration
 
         Schema::create($prefix.'ticket_followers', function (Blueprint $table) use ($prefix) {
             $table->foreignId('ticket_id')->constrained($prefix.'tickets')->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            // No DB-level FK to host `users` — see #88 / macros migration for rationale.
+            $table->unsignedBigInteger('user_id');
             $table->timestamps();
             $table->unique(['ticket_id', 'user_id']);
         });

--- a/database/migrations/2026_04_07_000001_add_snooze_columns_to_escalated_tickets.php
+++ b/database/migrations/2026_04_07_000001_add_snooze_columns_to_escalated_tickets.php
@@ -12,13 +12,9 @@ return new class extends Migration
 
         Schema::table($prefix.'tickets', function (Blueprint $table) {
             $table->dateTime('snoozed_until')->nullable()->after('closed_at');
+            // No DB-level FK to host `users` — see #88 / macros migration for rationale.
             $table->unsignedBigInteger('snoozed_by')->nullable()->after('snoozed_until');
             $table->string('status_before_snooze')->nullable()->after('snoozed_by');
-
-            $table->foreign('snoozed_by')
-                ->references('id')
-                ->on('users')
-                ->nullOnDelete();
 
             $table->index('snoozed_until');
         });
@@ -29,7 +25,6 @@ return new class extends Migration
         $prefix = config('escalated.table_prefix', 'escalated_');
 
         Schema::table($prefix.'tickets', function (Blueprint $table) {
-            $table->dropForeign(['snoozed_by']);
             $table->dropIndex(['snoozed_until']);
             $table->dropColumn(['snoozed_until', 'snoozed_by', 'status_before_snooze']);
         });

--- a/database/migrations/2026_04_07_000001_create_escalated_saved_views_table.php
+++ b/database/migrations/2026_04_07_000001_create_escalated_saved_views_table.php
@@ -14,7 +14,8 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->json('filters');
-            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            // No DB-level FK to host `users` — see #88 / macros migration for rationale.
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->boolean('is_shared')->default(false);
             $table->boolean('is_default')->default(false);
             $table->integer('position')->default(0);

--- a/database/migrations/2026_04_07_100001_create_escalated_mentions_table.php
+++ b/database/migrations/2026_04_07_100001_create_escalated_mentions_table.php
@@ -13,7 +13,8 @@ return new class extends Migration
         Schema::create($prefix.'mentions', function (Blueprint $table) use ($prefix) {
             $table->id();
             $table->foreignId('reply_id')->constrained($prefix.'replies')->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            // No DB-level FK to host `users` — see #88 / macros migration for rationale.
+            $table->unsignedBigInteger('user_id');
             $table->datetime('read_at')->nullable();
             $table->timestamps();
 


### PR DESCRIPTION
## Summary

Resolves the actual root cause of #88. The verbose migrate output the reporter shared showed:

```
SQLSTATE[HY000]: General error: 1005 Can't create table `yog_stock`.`escalated_macros`
(errno: 150 "Foreign key constraint is incorrectly formed")
SQL: alter table `escalated_macros` add constraint `escalated_macros_created_by_foreign`
foreign key (`created_by`) references `users` (`id`) on delete set null
```

This is the legacy MariaDB / MySQL 5.x wording for FK column-type incompatibility on the parent side. Reproduced his exact error message on MariaDB 11 under four common host configurations:

| Scenario | Triggers errno 150 |
|---|---|
| `users` table on MyISAM (legacy Laragon/WAMP `default_storage_engine=MyISAM`) | yes |
| `users.id` is signed BIGINT (project upgraded from Laravel pre-5.8) | yes |
| `users.id` is INT UNSIGNED (project from pre-5.8 `increments()`) | yes |
| `users.id` is CHAR(36) UUID (`HasUuids` user model) | yes |
| Charset / collation / row-format mismatches | no (MariaDB tolerates these) |

We can't control any of these four from a package, so the fix is to stop FK'ing to the host's `users` table. spatie/laravel-permission, spatie/laravel-activitylog, and filament/filament all follow the same pattern for the same reason.

## Changes

Five migrations drop their `constrained('users')` clause. Each becomes a plain `unsignedBigInteger` column:

- `escalated_macros.created_by` (was `nullable()->constrained('users')->nullOnDelete()`)
- `escalated_ticket_followers.user_id` (was `constrained('users')->cascadeOnDelete()`)
- `escalated_saved_views.user_id` (was `nullable()->constrained('users')->nullOnDelete()`)
- `escalated_mentions.user_id` (was `constrained('users')->cascadeOnDelete()`)
- `escalated_tickets.snoozed_by` (was `foreign(...)->references('id')->on('users')->nullOnDelete()`)

FK constraints to **our own** tables (e.g. `escalated_tickets`) remain — we control those, so they always work.

## Backwards compatibility

Forward-compatible only. Anyone with a successful prior install keeps their existing FK constraints; Laravel doesn't re-run migrations once recorded. Anyone hit by #88 sees migrations 14+ run cleanly on their next `php artisan migrate`.

## Application-level cleanup on user deletion

Previously the FK's `cascadeOnDelete` / `nullOnDelete` happened automatically. Now it doesn't, so orphaned rows could accumulate if a host app hard-deletes users. Most Laravel apps soft-delete users so this is a non-issue in practice, but worth flagging as a follow-up: add a User-deleting observer that fans out cleanup. Out of scope for this PR.

## Test plan

- [x] `pest` full suite — 609 passed (1 pre-existing risky in PluginService)
- [x] Verified the actual SQL output of each affected migration via the install command's new verbose mode (#91) — no FK statement is emitted
- [ ] CI green
- [ ] Manual: install fresh against a MariaDB host with `default_storage_engine=MyISAM` and confirm the install completes

Refs #88. Pairs with #91 (install diagnostics) which surfaced the underlying error.
