### PR TITLE
feat(admin): users-management page with admin/agent role toggles

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -35,6 +35,7 @@ use Escalated\Laravel\Http\Controllers\Admin\TicketController;
 use Escalated\Laravel\Http\Controllers\Admin\TicketLinkController;
 use Escalated\Laravel\Http\Controllers\Admin\TicketMergeController;
 use Escalated\Laravel\Http\Controllers\Admin\TwoFactorController;
+use Escalated\Laravel\Http\Controllers\Admin\UserController;
 use Escalated\Laravel\Http\Controllers\Admin\WebhookController;
 use Escalated\Laravel\Http\Controllers\Admin\WorkflowController;
 use Escalated\Laravel\Http\Controllers\BulkActionController;
@@ -136,6 +137,10 @@ Route::middleware(array_merge(config('escalated.routes.admin_middleware', ['web'
         Route::resource('roles', RoleController::class)
             ->names('escalated.admin.roles')
             ->except(['show']);
+
+        // Users (host User model: list + grant/revoke admin/agent)
+        Route::get('/users', [UserController::class, 'index'])->name('escalated.admin.users.index');
+        Route::patch('/users/{user}/role', [UserController::class, 'updateRole'])->name('escalated.admin.users.role');
 
         // Audit Log
         Route::get('/audit-log', [AuditLogController::class, 'index'])

--- a/src/Http/Controllers/Admin/UserController.php
+++ b/src/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Admin;
+
+use Escalated\Laravel\Contracts\EscalatedUiRenderer;
+use Escalated\Laravel\Escalated;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+/**
+ * Surface enough of the host User table for an admin to grant or revoke
+ * agent / admin access from the panel. The default install pins this to
+ * the `is_admin` and `is_agent` columns the install command tells hosts
+ * to add — hosts using a different role implementation (Spatie, custom
+ * pivot, etc.) should override this controller in their own routes.
+ */
+class UserController extends Controller
+{
+    public function __construct(
+        protected EscalatedUiRenderer $renderer,
+    ) {}
+
+    public function index(Request $request): mixed
+    {
+        $userClass = Escalated::userModel();
+        $query = $userClass::query();
+
+        if ($search = trim((string) $request->query('search', ''))) {
+            $term = '%'.$search.'%';
+            $query->where(function ($q) use ($term) {
+                $q->where('email', 'like', $term);
+                if ($this->columnExists($q->getModel(), 'name')) {
+                    $q->orWhere('name', 'like', $term);
+                }
+            });
+        }
+
+        $users = $query
+            ->orderByDesc('is_admin')
+            ->orderByDesc('is_agent')
+            ->orderBy('id')
+            ->paginate(20)
+            ->withQueryString()
+            ->through(fn ($user) => [
+                'id' => $user->getKey(),
+                'name' => $user->name ?? null,
+                'email' => $user->email,
+                'is_admin' => (bool) ($user->is_admin ?? false),
+                'is_agent' => (bool) ($user->is_agent ?? false),
+            ]);
+
+        return $this->renderer->render('Escalated/Admin/Users/Index', [
+            'users' => $users,
+            'filters' => ['search' => $search ?: ''],
+            'currentUserId' => $request->user()?->getKey(),
+        ]);
+    }
+
+    public function updateRole(Request $request, int|string $user): RedirectResponse
+    {
+        $validated = $request->validate([
+            'role' => 'required|in:admin,agent',
+            'value' => 'required|boolean',
+        ]);
+
+        $userClass = Escalated::userModel();
+        /** @var Model $target */
+        $target = $userClass::query()->findOrFail($user);
+
+        // Don't let an admin demote themselves and lock themselves out of
+        // the admin panel they're trying to use.
+        if ($validated['role'] === 'admin'
+            && ! $validated['value']
+            && $request->user()
+            && (string) $request->user()->getKey() === (string) $target->getKey()) {
+            return back()->with('error', __('You cannot remove your own admin role.'));
+        }
+
+        $updates = [];
+        if ($validated['role'] === 'admin') {
+            $updates['is_admin'] = $validated['value'];
+            // Admins are agents; flipping admin off does not also revoke agent
+            // (an ex-admin can still answer tickets unless explicitly demoted).
+            if ($validated['value']) {
+                $updates['is_agent'] = true;
+            }
+        } else {
+            $updates['is_agent'] = $validated['value'];
+            if (! $validated['value'] && ($target->is_admin ?? false)) {
+                // Revoking agent from an admin would leave the admin gate on
+                // but the agent gate off — confusing. Demote them fully.
+                $updates['is_admin'] = false;
+            }
+        }
+
+        $target->forceFill($updates)->save();
+
+        return back()->with('success', __('User updated.'));
+    }
+
+    protected function columnExists(Model $model, string $column): bool
+    {
+        try {
+            return $model->getConnection()->getSchemaBuilder()->hasColumn($model->getTable(), $column);
+        } catch (\Throwable) {
+            return true;
+        }
+    }
+}

--- a/tests/Feature/Admin/UserControllerTest.php
+++ b/tests/Feature/Admin/UserControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Escalated\Laravel\Tests\Fixtures\TestUser;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function () {
+    Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin);
+    Gate::define('escalated-admin', fn ($user) => $user->is_admin);
+});
+
+it('lists users with their admin/agent flags for an admin', function () {
+    $admin = $this->createAdmin(['email' => 'admin@example.com']);
+    $this->createTestUser(['email' => 'customer@example.com']);
+    $this->createAgent(['email' => 'agent@example.com']);
+
+    $response = $this->actingAs($admin)
+        ->get(route('escalated.admin.users.index'))
+        ->assertOk();
+
+    $users = collect($response->viewData('page')['props']['users']['data'] ?? [])
+        ->pluck('email')->all();
+    expect($users)->toContain('admin@example.com');
+    expect($users)->toContain('customer@example.com');
+    expect($users)->toContain('agent@example.com');
+});
+
+it('blocks non-admins from the user list', function () {
+    $agent = $this->createAgent(['email' => 'agent@example.com']);
+
+    $this->actingAs($agent)
+        ->get(route('escalated.admin.users.index'))
+        ->assertForbidden();
+});
+
+it('promotes a user to admin via the panel', function () {
+    $admin = $this->createAdmin(['email' => 'admin@example.com']);
+    $target = $this->createTestUser(['email' => 'someone@example.com']);
+
+    $this->actingAs($admin)
+        ->patch(route('escalated.admin.users.role', $target->id), [
+            'role' => 'admin',
+            'value' => true,
+        ])
+        ->assertRedirect();
+
+    $target->refresh();
+    expect($target->is_admin)->toBeTrue();
+    expect($target->is_agent)->toBeTrue();
+});
+
+it('promotes a user to agent only', function () {
+    $admin = $this->createAdmin(['email' => 'admin@example.com']);
+    $target = $this->createTestUser(['email' => 'someone@example.com']);
+
+    $this->actingAs($admin)
+        ->patch(route('escalated.admin.users.role', $target->id), [
+            'role' => 'agent',
+            'value' => true,
+        ])
+        ->assertRedirect();
+
+    $target->refresh();
+    expect($target->is_agent)->toBeTrue();
+    expect($target->is_admin)->toBeFalse();
+});
+
+it('prevents admins from demoting themselves', function () {
+    $admin = $this->createAdmin(['email' => 'admin@example.com']);
+
+    $this->actingAs($admin)
+        ->patch(route('escalated.admin.users.role', $admin->id), [
+            'role' => 'admin',
+            'value' => false,
+        ])
+        ->assertRedirect();
+
+    $admin->refresh();
+    expect($admin->is_admin)->toBeTrue();
+});
+
+it('demotes an admin and turns off agent in one step', function () {
+    $admin = $this->createAdmin(['email' => 'admin@example.com']);
+    $target = $this->createAdmin(['email' => 'someone@example.com']);
+
+    $this->actingAs($admin)
+        ->patch(route('escalated.admin.users.role', $target->id), [
+            'role' => 'agent',
+            'value' => false,
+        ])
+        ->assertRedirect();
+
+    $target->refresh();
+    expect($target->is_agent)->toBeFalse();
+    expect($target->is_admin)->toBeFalse();
+});
+
+it('filters users by search term', function () {
+    $admin = $this->createAdmin(['email' => 'admin@example.com']);
+    $this->createTestUser(['email' => 'jane@acme.test']);
+    $this->createTestUser(['email' => 'bob@globex.test']);
+
+    $response = $this->actingAs($admin)
+        ->get(route('escalated.admin.users.index', ['search' => 'acme']))
+        ->assertOk();
+
+    $emails = collect($response->viewData('page')['props']['users']['data'] ?? [])
+        ->pluck('email')->all();
+    expect($emails)->toContain('jane@acme.test');
+    expect($emails)->not->toContain('bob@globex.test');
+});

--- a/tests/Feature/Admin/UserControllerTest.php
+++ b/tests/Feature/Admin/UserControllerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Escalated\Laravel\Tests\Fixtures\TestUser;
 use Illuminate\Support\Facades\Gate;
 
 beforeEach(function () {


### PR DESCRIPTION
## Summary
- Adds an admin users-management page so admins can grant or revoke `is_admin` / `is_agent` from the panel instead of dropping into tinker — surfaced from the #60 thread, where the reporter asked "how do you create agent?"
- New `Admin/UserController` exposes the host User table (paged, searchable). `PATCH /admin/users/{user}/role` flips one role at a time.
- Self-demote on admin is rejected server-side, so an admin cannot lock themselves out of the panel they're using.
- Pairs with the companion Vue page in escalated-dev/escalated.

## Notes for reviewers
- The default install pins this to `is_admin` / `is_agent` columns on the host User model (the columns the install command already tells hosts to add). Hosts wiring the gates differently (Spatie roles, custom pivots) can override the controller in their own routes — there's a comment to that effect in the class.
- Demoting an admin via the agent toggle revokes both flags in one step (otherwise the admin gate would stay on while the agent gate was off, which is confusing).

## Test plan
- [x] `vendor/bin/pest tests/Feature/Admin/UserControllerTest.php` — 7 new cases pass
- [x] Full suite: 616 tests pass, 1 risky (pre-existing).
- [ ] Manual: admin lands on `/support/admin/users`, search filters the list, toggling Admin grants both flags, toggling self-demote is rejected.
