### PR TITLE
feat: implement skills-based routing

### DIFF
--- a/database/migrations/2026_02_24_000011_create_escalated_skills_table.php
+++ b/database/migrations/2026_02_24_000011_create_escalated_skills_table.php
@@ -14,6 +14,8 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('slug')->unique();
+            $table->json('routing_tag_ids')->nullable();
+            $table->json('routing_department_ids')->nullable();
             $table->timestamps();
         });
 

--- a/src/Http/Controllers/Admin/SkillController.php
+++ b/src/Http/Controllers/Admin/SkillController.php
@@ -138,7 +138,7 @@ class SkillController extends Controller
     protected function formPayload(): array
     {
         $userModel = Escalated::userModel();
-        $userInstance = new $userModel();
+        $userInstance = new $userModel;
         $userTable = $userInstance->getTable();
         $userKey = $userInstance->getKeyName();
 

--- a/src/Http/Controllers/Admin/SkillController.php
+++ b/src/Http/Controllers/Admin/SkillController.php
@@ -3,10 +3,15 @@
 namespace Escalated\Laravel\Http\Controllers\Admin;
 
 use Escalated\Laravel\Contracts\EscalatedUiRenderer;
+use Escalated\Laravel\Escalated;
+use Escalated\Laravel\Models\Department;
 use Escalated\Laravel\Models\Skill;
+use Escalated\Laravel\Models\Tag;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\Rule;
 
 class SkillController extends Controller
 {
@@ -16,7 +21,18 @@ class SkillController extends Controller
 
     public function index(): mixed
     {
-        $skills = Skill::withCount('agents')->orderBy('name')->get();
+        $skills = Skill::withCount('agents')
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Skill $skill) => [
+                'id' => $skill->id,
+                'name' => $skill->name,
+                'slug' => $skill->slug,
+                'agents_count' => $skill->agents_count,
+                'routing_tags_count' => count($skill->routing_tag_ids ?? []),
+                'routing_departments_count' => count($skill->routing_department_ids ?? []),
+                'updated_at' => $skill->updated_at?->toIso8601String(),
+            ]);
 
         return $this->renderer->render('Escalated/Admin/Skills/Index', [
             'skills' => $skills,
@@ -25,18 +41,20 @@ class SkillController extends Controller
 
     public function create(): mixed
     {
-        return $this->renderer->render('Escalated/Admin/Skills/Form');
+        return $this->renderer->render('Escalated/Admin/Skills/Form', $this->formPayload());
     }
 
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
-            'name' => 'required|string|max:255|unique:'.Skill::make()->getTable().',name',
+        $validated = $this->validatePayload($request);
+
+        $skill = Skill::create([
+            'name' => $validated['name'],
+            'routing_tag_ids' => $validated['routing_tag_ids'] ?? [],
+            'routing_department_ids' => $validated['routing_department_ids'] ?? [],
         ]);
 
-        Skill::create([
-            'name' => $request->input('name'),
-        ]);
+        $this->syncAgents($skill, $validated['agents'] ?? []);
 
         return redirect()->route('escalated.admin.skills.index')
             ->with('success', 'Skill created.');
@@ -44,20 +62,37 @@ class SkillController extends Controller
 
     public function edit(Skill $skill): mixed
     {
+        $skill->load('agents');
+
         return $this->renderer->render('Escalated/Admin/Skills/Form', [
-            'skill' => $skill,
+            ...$this->formPayload(),
+            'skill' => [
+                'id' => $skill->id,
+                'name' => $skill->name,
+                'slug' => $skill->slug,
+                'routing_tag_ids' => $skill->routing_tag_ids ?? [],
+                'routing_department_ids' => $skill->routing_department_ids ?? [],
+                'agents' => $skill->agents
+                    ->map(fn ($agent) => [
+                        'user_id' => $agent->getKey(),
+                        'proficiency' => (int) ($agent->pivot->proficiency ?? 1),
+                    ])
+                    ->values(),
+            ],
         ]);
     }
 
     public function update(Request $request, Skill $skill): RedirectResponse
     {
-        $request->validate([
-            'name' => 'required|string|max:255|unique:'.Skill::make()->getTable().',name,'.$skill->id,
-        ]);
+        $validated = $this->validatePayload($request, $skill);
 
         $skill->update([
-            'name' => $request->input('name'),
+            'name' => $validated['name'],
+            'routing_tag_ids' => $validated['routing_tag_ids'] ?? [],
+            'routing_department_ids' => $validated['routing_department_ids'] ?? [],
         ]);
+
+        $this->syncAgents($skill, $validated['agents'] ?? []);
 
         return redirect()->route('escalated.admin.skills.index')
             ->with('success', 'Skill updated.');
@@ -69,5 +104,67 @@ class SkillController extends Controller
 
         return redirect()->route('escalated.admin.skills.index')
             ->with('success', 'Skill deleted.');
+    }
+
+    protected function validatePayload(Request $request, ?Skill $skill = null): array
+    {
+        $userModel = Escalated::userModel();
+        $userTable = (new $userModel)->getTable();
+        $userKey = (new $userModel)->getKeyName();
+
+        return $request->validate([
+            'name' => ['required', 'string', 'max:255', Rule::unique(Skill::make()->getTable(), 'name')->ignore($skill?->id)],
+            'routing_tag_ids' => ['sometimes', 'array'],
+            'routing_tag_ids.*' => ['integer', Rule::exists(Tag::make()->getTable(), 'id')],
+            'routing_department_ids' => ['sometimes', 'array'],
+            'routing_department_ids.*' => ['integer', Rule::exists(Department::make()->getTable(), 'id')],
+            'agents' => ['sometimes', 'array'],
+            'agents.*.user_id' => ['required', 'integer', 'distinct', Rule::exists($userTable, $userKey)],
+            'agents.*.proficiency' => ['required', 'integer', 'between:1,5'],
+        ]);
+    }
+
+    protected function syncAgents(Skill $skill, array $agents): void
+    {
+        $payload = collect($agents)
+            ->mapWithKeys(fn (array $agent) => [
+                (int) $agent['user_id'] => ['proficiency' => (int) $agent['proficiency']],
+            ])
+            ->all();
+
+        $skill->agents()->sync($payload);
+    }
+
+    protected function formPayload(): array
+    {
+        $userModel = Escalated::userModel();
+        $userInstance = new $userModel();
+        $userTable = $userInstance->getTable();
+        $userKey = $userInstance->getKeyName();
+
+        $agentQuery = $userModel::query()->orderBy('name');
+        $columns = Schema::getColumnListing($userTable);
+        if (in_array('is_agent', $columns, true) || in_array('is_admin', $columns, true)) {
+            $agentQuery->where(function ($query) use ($columns) {
+                if (in_array('is_agent', $columns, true)) {
+                    $query->orWhere('is_agent', true);
+                }
+                if (in_array('is_admin', $columns, true)) {
+                    $query->orWhere('is_admin', true);
+                }
+            });
+        }
+
+        return [
+            'availableAgents' => $agentQuery->get([$userKey, 'name', 'email'])
+                ->map(fn ($agent) => [
+                    'id' => $agent->getKey(),
+                    'name' => $agent->name,
+                    'email' => $agent->email,
+                ])
+                ->values(),
+            'availableTags' => Tag::query()->orderBy('name')->get(['id', 'name', 'color']),
+            'availableDepartments' => Department::query()->orderBy('name')->get(['id', 'name']),
+        ];
     }
 }

--- a/src/Listeners/AutoAssignTicket.php
+++ b/src/Listeners/AutoAssignTicket.php
@@ -18,7 +18,7 @@ class AutoAssignTicket
 
         $ticket = $event->ticket;
 
-        if ($ticket->assigned_to === null && $ticket->department_id !== null) {
+        if ($ticket->assigned_to === null) {
             $this->assignmentService->autoAssign($ticket);
         }
     }

--- a/src/Models/Skill.php
+++ b/src/Models/Skill.php
@@ -3,13 +3,21 @@
 namespace Escalated\Laravel\Models;
 
 use Escalated\Laravel\Escalated;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class Skill extends Model
 {
     protected $guarded = ['id'];
+
+    protected function casts(): array
+    {
+        return [
+            'routing_tag_ids' => 'array',
+            'routing_department_ids' => 'array',
+        ];
+    }
 
     public function getTable(): string
     {
@@ -32,6 +40,11 @@ class Skill extends Model
             if (empty($skill->slug)) {
                 $skill->slug = Str::slug($skill->name);
             }
+        });
+
+        static::saving(function (self $skill) {
+            $skill->routing_tag_ids = array_values(array_unique(array_map('intval', $skill->routing_tag_ids ?? [])));
+            $skill->routing_department_ids = array_values(array_unique(array_map('intval', $skill->routing_department_ids ?? [])));
         });
     }
 }

--- a/src/Models/Skill.php
+++ b/src/Models/Skill.php
@@ -3,8 +3,8 @@
 namespace Escalated\Laravel\Models;
 
 use Escalated\Laravel\Escalated;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
 
 class Skill extends Model

--- a/src/Services/AssignmentService.php
+++ b/src/Services/AssignmentService.php
@@ -9,7 +9,10 @@ use Escalated\Laravel\Models\Ticket;
 
 class AssignmentService
 {
-    public function __construct(protected EscalatedManager $manager) {}
+    public function __construct(
+        protected EscalatedManager $manager,
+        protected SkillRoutingService $skillRoutingService,
+    ) {}
 
     public function assign(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket
     {
@@ -28,6 +31,11 @@ class AssignmentService
 
     public function autoAssign(Ticket $ticket): ?Ticket
     {
+        $matchedAgent = $this->skillRoutingService->findMatchingAgents($ticket)->first();
+        if ($matchedAgent) {
+            return $this->assign($ticket, $matchedAgent->getKey());
+        }
+
         if (! $ticket->department_id) {
             return null;
         }

--- a/src/Services/SkillRoutingService.php
+++ b/src/Services/SkillRoutingService.php
@@ -11,50 +11,94 @@ use Illuminate\Support\Facades\DB;
 class SkillRoutingService
 {
     /**
-     * Find agents with skills matching ticket tags, sorted by current load.
+     * Find agents with skills matching ticket tags and/or department,
+     * sorted by skill coverage, total proficiency, then current load.
      *
-     * Maps ticket tags to skills by name, then finds agents
-     * who have those skills, ordered by current open ticket count (ascending).
+     * Explicit routing rules win: a skill may target ticket tags and/or
+     * departments. If a skill has no routing arrays configured, we fall
+     * back to name-based tag matching to preserve earlier placeholder
+     * behavior.
      */
     public function findMatchingAgents(Ticket $ticket): Collection
     {
-        // Get the ticket's tag names
-        $tagNames = $ticket->tags()->pluck('name')->toArray();
+        $tagIds = $ticket->tags()->pluck('id')->map(fn ($id) => (int) $id)->all();
+        $tagNames = $ticket->tags()->pluck('name')->map(fn ($name) => mb_strtolower((string) $name))->all();
+        $departmentId = $ticket->department_id ? (int) $ticket->department_id : null;
 
-        if (empty($tagNames)) {
+        if (empty($tagIds) && $departmentId === null && empty($tagNames)) {
             return collect();
         }
 
-        // Find skills that match tag names
-        $skillIds = Skill::whereIn('name', $tagNames)->pluck('id')->toArray();
-
-        if (empty($skillIds)) {
-            return collect();
-        }
-
-        // Find agents with matching skills
-        $agentSkillTable = Escalated::table('agent_skill');
-        $ticketsTable = Escalated::table('tickets');
-
-        $agents = DB::table($agentSkillTable)
-            ->whereIn('skill_id', $skillIds)
-            ->select('user_id')
-            ->distinct()
+        $matchingSkills = Skill::query()
             ->get()
-            ->pluck('user_id');
+            ->filter(function (Skill $skill) use ($tagIds, $tagNames, $departmentId) {
+                $routingTagIds = array_map('intval', $skill->routing_tag_ids ?? []);
+                $routingDepartmentIds = array_map('intval', $skill->routing_department_ids ?? []);
+                $hasExplicitRules = $routingTagIds !== [] || $routingDepartmentIds !== [];
 
-        if ($agents->isEmpty()) {
+                if ($hasExplicitRules) {
+                    return ($routingTagIds !== [] && array_intersect($routingTagIds, $tagIds) !== [])
+                        || ($departmentId !== null && in_array($departmentId, $routingDepartmentIds, true));
+                }
+
+                return in_array(mb_strtolower($skill->name), $tagNames, true);
+            })
+            ->values();
+
+        if ($matchingSkills->isEmpty()) {
             return collect();
         }
 
-        // Load agents with their current open ticket count, sorted by load
-        $userModel = Escalated::userModel();
+        $agentSkillTable = Escalated::table('agent_skill');
+        $skillIds = $matchingSkills->pluck('id')->all();
 
-        return $userModel::whereIn((new $userModel)->getKeyName(), $agents->toArray())
-            ->withCount(['tickets as open_tickets_count' => function ($q) {
-                $q->whereNotIn('status', ['resolved', 'closed']);
-            }])
-            ->orderBy('open_tickets_count', 'asc')
-            ->get();
+        $agentSkillRows = DB::table($agentSkillTable)
+            ->whereIn('skill_id', $skillIds)
+            ->get(['user_id', 'skill_id', 'proficiency']);
+
+        if ($agentSkillRows->isEmpty()) {
+            return collect();
+        }
+
+        $userModel = Escalated::userModel();
+        $userKey = (new $userModel)->getKeyName();
+        $agentIds = $agentSkillRows->pluck('user_id')->map(fn ($id) => (int) $id)->unique()->values();
+
+        $openTicketCounts = Ticket::query()
+            ->open()
+            ->whereIn('assigned_to', $agentIds->all())
+            ->selectRaw('assigned_to, COUNT(*) as aggregate')
+            ->groupBy('assigned_to')
+            ->pluck('aggregate', 'assigned_to');
+
+        $rowsByUser = $agentSkillRows->groupBy('user_id');
+        $agents = $userModel::query()
+            ->whereIn($userKey, $agentIds->all())
+            ->get()
+            ->map(function ($agent) use ($rowsByUser, $openTicketCounts, $skillIds) {
+                $rows = $rowsByUser->get($agent->getKey(), collect());
+                $matchedSkillIds = $rows->pluck('skill_id')->map(fn ($id) => (int) $id)->intersect($skillIds)->unique();
+                $agent->matched_skill_count = $matchedSkillIds->count();
+                $agent->total_skill_proficiency = (int) $rows->sum('proficiency');
+                $agent->open_tickets_count = (int) ($openTicketCounts[$agent->getKey()] ?? 0);
+
+                return $agent;
+            })
+            ->filter(fn ($agent) => $agent->matched_skill_count > 0)
+            ->values();
+
+        return $agents->sort(function ($left, $right) {
+            return [
+                $right->matched_skill_count,
+                $right->total_skill_proficiency,
+                $left->open_tickets_count,
+                mb_strtolower((string) $left->name),
+            ] <=> [
+                $left->matched_skill_count,
+                $left->total_skill_proficiency,
+                $right->open_tickets_count,
+                mb_strtolower((string) $right->name),
+            ];
+        })->values();
     }
 }

--- a/tests/Feature/Admin/SkillControllerTest.php
+++ b/tests/Feature/Admin/SkillControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Escalated\Laravel\Models\Department;
+use Escalated\Laravel\Models\Skill;
+use Escalated\Laravel\Models\Tag;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function () {
+    Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin);
+    Gate::define('escalated-admin', fn ($user) => $user->is_admin);
+});
+
+it('lists skills in the admin area', function () {
+    $admin = $this->createAdmin();
+    Skill::create(['name' => 'Billing']);
+
+    $this->actingAs($admin)
+        ->get(route('escalated.admin.skills.index'))
+        ->assertOk();
+});
+
+it('creates a skill with agent assignments and routing rules', function () {
+    $admin = $this->createAdmin();
+    $agent = $this->createAgent(['email' => 'skill-agent@example.com']);
+    $tag = Tag::factory()->create(['name' => 'Spanish']);
+    $department = Department::factory()->create(['name' => 'Billing']);
+
+    $this->actingAs($admin)
+        ->post(route('escalated.admin.skills.store'), [
+            'name' => 'Spanish',
+            'routing_tag_ids' => [$tag->id],
+            'routing_department_ids' => [$department->id],
+            'agents' => [
+                ['user_id' => $agent->id, 'proficiency' => 5],
+            ],
+        ])
+        ->assertRedirect(route('escalated.admin.skills.index'));
+
+    $skill = Skill::query()->where('name', 'Spanish')->firstOrFail();
+    expect($skill->routing_tag_ids)->toBe([$tag->id]);
+    expect($skill->routing_department_ids)->toBe([$department->id]);
+    expect($skill->agents()->first()?->pivot?->proficiency)->toBe(5);
+});
+
+it('updates skill routing rules and re-syncs agent proficiencies', function () {
+    $admin = $this->createAdmin();
+    $agentOne = $this->createAgent(['email' => 'skill-agent-1@example.com']);
+    $agentTwo = $this->createAgent(['email' => 'skill-agent-2@example.com']);
+    $tag = Tag::factory()->create(['name' => 'Technical']);
+    $department = Department::factory()->create(['name' => 'Engineering']);
+    $skill = Skill::create(['name' => 'Technical']);
+    $skill->agents()->sync([$agentOne->id => ['proficiency' => 2]]);
+
+    $this->actingAs($admin)
+        ->put(route('escalated.admin.skills.update', $skill), [
+            'name' => 'Technical',
+            'routing_tag_ids' => [$tag->id],
+            'routing_department_ids' => [$department->id],
+            'agents' => [
+                ['user_id' => $agentTwo->id, 'proficiency' => 4],
+            ],
+        ])
+        ->assertRedirect(route('escalated.admin.skills.index'));
+
+    $skill->refresh();
+    expect($skill->routing_tag_ids)->toBe([$tag->id]);
+    expect($skill->routing_department_ids)->toBe([$department->id]);
+    expect($skill->agents->pluck('id')->all())->toBe([$agentTwo->id]);
+    expect($skill->agents()->first()?->pivot?->proficiency)->toBe(4);
+});

--- a/tests/Unit/SkillRoutingServiceTest.php
+++ b/tests/Unit/SkillRoutingServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Escalated\Laravel\Models\Department;
+use Escalated\Laravel\Models\Skill;
+use Escalated\Laravel\Models\Tag;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Services\AssignmentService;
+use Escalated\Laravel\Services\SkillRoutingService;
+
+it('orders matching agents by skill coverage, proficiency, then load', function () {
+    $department = Department::factory()->create(['name' => 'Billing']);
+    $tag = Tag::factory()->create(['name' => 'Spanish']);
+
+    $agentHighCoverage = $this->createAgent(['name' => 'Agent High Coverage', 'email' => 'coverage@example.com']);
+    $agentLowCoverage = $this->createAgent(['name' => 'Agent Low Coverage', 'email' => 'low@example.com']);
+    $agentLowerProficiency = $this->createAgent(['name' => 'Agent Lower Proficiency', 'email' => 'lower@example.com']);
+
+    $spanishSkill = Skill::create([
+        'name' => 'Spanish',
+        'routing_tag_ids' => [$tag->id],
+    ]);
+    $billingSkill = Skill::create([
+        'name' => 'Billing',
+        'routing_department_ids' => [$department->id],
+    ]);
+
+    $spanishSkill->agents()->sync([
+        $agentHighCoverage->id => ['proficiency' => 5],
+        $agentLowCoverage->id => ['proficiency' => 5],
+        $agentLowerProficiency->id => ['proficiency' => 3],
+    ]);
+    $billingSkill->agents()->sync([
+        $agentHighCoverage->id => ['proficiency' => 4],
+        $agentLowerProficiency->id => ['proficiency' => 2],
+    ]);
+
+    Ticket::factory()->count(3)->assigned($agentHighCoverage->id)->open()->create();
+    Ticket::factory()->assigned($agentLowCoverage->id)->open()->create();
+
+    $ticket = Ticket::factory()->create(['department_id' => $department->id]);
+    $ticket->tags()->attach($tag->id);
+
+    $agents = app(SkillRoutingService::class)->findMatchingAgents($ticket);
+
+    expect($agents->pluck('id')->all())->toBe([
+        $agentHighCoverage->id,
+        $agentLowerProficiency->id,
+        $agentLowCoverage->id,
+    ]);
+    expect($agents->first()->matched_skill_count)->toBe(2);
+    expect($agents->first()->total_skill_proficiency)->toBe(9);
+});
+
+it('auto assign prefers skill-matched agents before department load balancing', function () {
+    $customer = $this->createTestUser(['email' => 'customer@example.com']);
+    $department = Department::factory()->create(['name' => 'Technical']);
+    $departmentOnlyAgent = $this->createAgent(['name' => 'Department Only', 'email' => 'dept@example.com']);
+    $skilledAgent = $this->createAgent(['name' => 'Skilled Agent', 'email' => 'skilled@example.com']);
+    $tag = Tag::factory()->create(['name' => 'French']);
+
+    $department->agents()->sync([$departmentOnlyAgent->id, $skilledAgent->id]);
+
+    $skill = Skill::create([
+        'name' => 'French',
+        'routing_tag_ids' => [$tag->id],
+    ]);
+    $skill->agents()->sync([$skilledAgent->id => ['proficiency' => 5]]);
+
+    Ticket::factory()->count(2)->assigned($skilledAgent->id)->open()->create();
+
+    $ticket = Ticket::factory()
+        ->forRequester($customer->getMorphClass(), $customer->id)
+        ->create(['department_id' => $department->id]);
+    $ticket->tags()->attach($tag->id);
+
+    $assigned = app(AssignmentService::class)->autoAssign($ticket);
+
+    expect($assigned)->not->toBeNull();
+    expect($assigned?->assigned_to)->toBe($skilledAgent->id);
+});


### PR DESCRIPTION
## Summary
- add skill routing metadata and admin CRUD support
- route ticket assignment through configured skills before department fallback
- add backend coverage for admin skill management and routing behavior

## Verification
- vendor\\bin\\pest tests/Feature/Admin/SkillControllerTest.php tests/Unit/SkillRoutingServiceTest.php