### PR TITLE
feat: expand SSO provider configuration

### DIFF
--- a/src/Http/Controllers/Admin/SsoSettingsController.php
+++ b/src/Http/Controllers/Admin/SsoSettingsController.php
@@ -23,16 +23,48 @@ class SsoSettingsController extends Controller
     public function update(Request $request, SsoService $sso)
     {
         $validated = $request->validate([
-            'sso_provider' => ['required', 'string', 'in:none,saml,jwt'],
+            'sso_provider' => ['required', 'string', 'in:none,saml,jwt,oauth'],
             'sso_entity_id' => ['nullable', 'string', 'max:500'],
             'sso_url' => ['nullable', 'url', 'max:500'],
-            'sso_certificate' => ['nullable', 'string', 'max:5000'],
+            'sso_login_url' => ['nullable', 'url', 'max:500'],
+            'sso_logout_url' => ['nullable', 'url', 'max:500'],
+            'sso_metadata_url' => ['nullable', 'url', 'max:500'],
+            'sso_certificate' => ['nullable', 'string', 'max:10000'],
             'sso_attr_email' => ['nullable', 'string', 'max:100'],
             'sso_attr_name' => ['nullable', 'string', 'max:100'],
             'sso_attr_role' => ['nullable', 'string', 'max:100'],
             'sso_jwt_secret' => ['nullable', 'string', 'max:500'],
-            'sso_jwt_algorithm' => ['nullable', 'string', 'in:HS256,HS384,HS512,RS256'],
+            'sso_jwt_algorithm' => ['nullable', 'string', 'in:HS256,HS384,HS512,RS256,RS384,RS512'],
+            'sso_oauth_authorize_url' => ['nullable', 'url', 'max:500'],
+            'sso_oauth_token_url' => ['nullable', 'url', 'max:500'],
+            'sso_oauth_userinfo_url' => ['nullable', 'url', 'max:500'],
+            'sso_oauth_client_id' => ['nullable', 'string', 'max:255'],
+            'sso_oauth_client_secret' => ['nullable', 'string', 'max:500'],
+            'sso_oauth_scopes' => ['nullable', 'string', 'max:255'],
         ]);
+
+        if ($validated['sso_provider'] === 'saml') {
+            $request->validate([
+                'sso_entity_id' => ['required', 'string', 'max:500'],
+                'sso_login_url' => ['required', 'url', 'max:500'],
+            ]);
+        }
+
+        if ($validated['sso_provider'] === 'jwt') {
+            $request->validate([
+                'sso_url' => ['required', 'url', 'max:500'],
+                'sso_jwt_secret' => ['required', 'string', 'max:500'],
+            ]);
+        }
+
+        if ($validated['sso_provider'] === 'oauth') {
+            $request->validate([
+                'sso_oauth_authorize_url' => ['required', 'url', 'max:500'],
+                'sso_oauth_token_url' => ['required', 'url', 'max:500'],
+                'sso_oauth_userinfo_url' => ['required', 'url', 'max:500'],
+                'sso_oauth_client_id' => ['required', 'string', 'max:255'],
+            ]);
+        }
 
         $sso->saveConfig($validated);
 

--- a/src/Services/SsoService.php
+++ b/src/Services/SsoService.php
@@ -13,12 +13,21 @@ class SsoService
         'sso_provider' => 'none',
         'sso_entity_id' => '',
         'sso_url' => '',
+        'sso_login_url' => '',
+        'sso_logout_url' => '',
+        'sso_metadata_url' => '',
         'sso_certificate' => '',
         'sso_attr_email' => 'email',
         'sso_attr_name' => 'name',
         'sso_attr_role' => 'role',
         'sso_jwt_secret' => '',
         'sso_jwt_algorithm' => 'HS256',
+        'sso_oauth_authorize_url' => '',
+        'sso_oauth_token_url' => '',
+        'sso_oauth_userinfo_url' => '',
+        'sso_oauth_client_id' => '',
+        'sso_oauth_client_secret' => '',
+        'sso_oauth_scopes' => 'openid profile email',
     ];
 
     /**
@@ -30,6 +39,21 @@ class SsoService
 
         foreach ($this->configKeys as $key => $default) {
             $config[$key] = EscalatedSettings::get($key, $default);
+        }
+
+        $legacyUrl = trim((string) ($config['sso_url'] ?? ''));
+        if ($legacyUrl !== '') {
+            if ($config['sso_login_url'] === '') {
+                $config['sso_login_url'] = $legacyUrl;
+            }
+
+            if ($config['sso_provider'] === 'oauth') {
+                if ($config['sso_oauth_authorize_url'] === '') {
+                    $config['sso_oauth_authorize_url'] = $legacyUrl;
+                }
+            } elseif ($config['sso_provider'] === 'saml' && $config['sso_metadata_url'] === '') {
+                $config['sso_metadata_url'] = $legacyUrl;
+            }
         }
 
         return $config;

--- a/tests/Feature/Admin/SsoSettingsControllerTest.php
+++ b/tests/Feature/Admin/SsoSettingsControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Escalated\Laravel\Models\EscalatedSettings;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function () {
+    Gate::define('escalated-agent', fn ($user) => $user->is_agent || $user->is_admin);
+    Gate::define('escalated-admin', fn ($user) => $user->is_admin);
+});
+
+it('shows the sso settings page', function () {
+    $admin = $this->createAdmin();
+
+    $this->actingAs($admin)
+        ->get(route('escalated.admin.settings.sso'))
+        ->assertOk();
+});
+
+it('stores oauth configuration', function () {
+    $admin = $this->createAdmin();
+
+    $this->actingAs($admin)
+        ->post(route('escalated.admin.settings.sso.update'), [
+            'sso_provider' => 'oauth',
+            'sso_oauth_authorize_url' => 'https://id.example.com/oauth/authorize',
+            'sso_oauth_token_url' => 'https://id.example.com/oauth/token',
+            'sso_oauth_userinfo_url' => 'https://id.example.com/oauth/userinfo',
+            'sso_oauth_client_id' => 'client-id',
+            'sso_oauth_client_secret' => 'client-secret',
+            'sso_oauth_scopes' => 'openid profile email',
+            'sso_attr_email' => 'email',
+            'sso_attr_name' => 'name',
+            'sso_attr_role' => 'role',
+        ])
+        ->assertRedirect();
+
+    expect(EscalatedSettings::get('sso_provider'))->toBe('oauth');
+    expect(EscalatedSettings::get('sso_oauth_token_url'))->toBe('https://id.example.com/oauth/token');
+});
+
+it('requires oauth endpoints and client id when oauth is enabled', function () {
+    $admin = $this->createAdmin();
+
+    $this->actingAs($admin)
+        ->from(route('escalated.admin.settings.sso'))
+        ->post(route('escalated.admin.settings.sso.update'), [
+            'sso_provider' => 'oauth',
+        ])
+        ->assertSessionHasErrors([
+            'sso_oauth_authorize_url',
+            'sso_oauth_token_url',
+            'sso_oauth_userinfo_url',
+            'sso_oauth_client_id',
+        ]);
+});

--- a/tests/Unit/SsoServiceTest.php
+++ b/tests/Unit/SsoServiceTest.php
@@ -120,6 +120,7 @@ describe('SSO Config', function () {
 
         expect($config['sso_provider'])->toBe('none');
         expect($config['sso_jwt_algorithm'])->toBe('HS256');
+        expect($config['sso_oauth_scopes'])->toBe('openid profile email');
     });
 
     it('reports disabled when provider is none', function () {
@@ -133,13 +134,28 @@ describe('SSO Config', function () {
 
     it('saves and retrieves config', function () {
         $this->service->saveConfig([
-            'sso_provider' => 'jwt',
-            'sso_jwt_secret' => 'my-secret',
+            'sso_provider' => 'oauth',
+            'sso_oauth_authorize_url' => 'https://id.example.com/oauth/authorize',
+            'sso_oauth_token_url' => 'https://id.example.com/oauth/token',
+            'sso_oauth_userinfo_url' => 'https://id.example.com/oauth/userinfo',
+            'sso_oauth_client_id' => 'client-id',
+            'sso_oauth_client_secret' => 'client-secret',
         ]);
 
         $config = $this->service->getConfig();
-        expect($config['sso_provider'])->toBe('jwt');
-        expect($config['sso_jwt_secret'])->toBe('my-secret');
+        expect($config['sso_provider'])->toBe('oauth');
+        expect($config['sso_oauth_authorize_url'])->toBe('https://id.example.com/oauth/authorize');
+        expect($config['sso_oauth_client_secret'])->toBe('client-secret');
+    });
+
+    it('hydrates provider specific urls from the legacy url setting', function () {
+        EscalatedSettings::set('sso_provider', 'saml');
+        EscalatedSettings::set('sso_url', 'https://id.example.com/sso');
+
+        $config = $this->service->getConfig();
+
+        expect($config['sso_login_url'])->toBe('https://id.example.com/sso');
+        expect($config['sso_metadata_url'])->toBe('https://id.example.com/sso');
     });
 });
 


### PR DESCRIPTION
## Summary
- expand the stored SSO configuration to cover SAML, JWT, and OAuth settings
- add provider-aware validation plus admin settings coverage
- preserve legacy single-URL setups through config fallback handling

## Verification
- vendor\\bin\\pest tests/Feature/Admin/SsoSettingsControllerTest.php tests/Unit/SsoServiceTest.php