### PR TITLE
fix(skills): wrap store/update in transactions; restrict agents to role-bearing users

### DIFF
--- a/src/Http/Controllers/Admin/SkillController.php
+++ b/src/Http/Controllers/Admin/SkillController.php
@@ -10,6 +10,7 @@ use Escalated\Laravel\Models\Tag;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Validation\Rule;
 
@@ -48,13 +49,15 @@ class SkillController extends Controller
     {
         $validated = $this->validatePayload($request);
 
-        $skill = Skill::create([
-            'name' => $validated['name'],
-            'routing_tag_ids' => $validated['routing_tag_ids'] ?? [],
-            'routing_department_ids' => $validated['routing_department_ids'] ?? [],
-        ]);
+        DB::transaction(function () use ($validated): void {
+            $skill = Skill::create([
+                'name' => $validated['name'],
+                'routing_tag_ids' => $validated['routing_tag_ids'] ?? [],
+                'routing_department_ids' => $validated['routing_department_ids'] ?? [],
+            ]);
 
-        $this->syncAgents($skill, $validated['agents'] ?? []);
+            $this->syncAgents($skill, $validated['agents'] ?? []);
+        });
 
         return redirect()->route('escalated.admin.skills.index')
             ->with('success', 'Skill created.');
@@ -86,13 +89,15 @@ class SkillController extends Controller
     {
         $validated = $this->validatePayload($request, $skill);
 
-        $skill->update([
-            'name' => $validated['name'],
-            'routing_tag_ids' => $validated['routing_tag_ids'] ?? [],
-            'routing_department_ids' => $validated['routing_department_ids'] ?? [],
-        ]);
+        DB::transaction(function () use ($skill, $validated): void {
+            $skill->update([
+                'name' => $validated['name'],
+                'routing_tag_ids' => $validated['routing_tag_ids'] ?? [],
+                'routing_department_ids' => $validated['routing_department_ids'] ?? [],
+            ]);
 
-        $this->syncAgents($skill, $validated['agents'] ?? []);
+            $this->syncAgents($skill, $validated['agents'] ?? []);
+        });
 
         return redirect()->route('escalated.admin.skills.index')
             ->with('success', 'Skill updated.');
@@ -109,8 +114,10 @@ class SkillController extends Controller
     protected function validatePayload(Request $request, ?Skill $skill = null): array
     {
         $userModel = Escalated::userModel();
-        $userTable = (new $userModel)->getTable();
-        $userKey = (new $userModel)->getKeyName();
+        $userInstance = new $userModel;
+        $userTable = $userInstance->getTable();
+        $userKey = $userInstance->getKeyName();
+        $roleColumns = $this->userRoleColumns($userTable);
 
         return $request->validate([
             'name' => ['required', 'string', 'max:255', Rule::unique(Skill::make()->getTable(), 'name')->ignore($skill?->id)],
@@ -119,9 +126,53 @@ class SkillController extends Controller
             'routing_department_ids' => ['sometimes', 'array'],
             'routing_department_ids.*' => ['integer', Rule::exists(Department::make()->getTable(), 'id')],
             'agents' => ['sometimes', 'array'],
-            'agents.*.user_id' => ['required', 'integer', 'distinct', Rule::exists($userTable, $userKey)],
+            'agents.*.user_id' => [
+                'required',
+                'integer',
+                'distinct',
+                Rule::exists($userTable, $userKey),
+                $this->agentRoleRule($userModel, $userKey, $roleColumns),
+            ],
             'agents.*.proficiency' => ['required', 'integer', 'between:1,5'],
         ]);
+    }
+
+    /**
+     * Closure rule asserting the user_id refers to a user who qualifies as an
+     * agent (`is_agent` or `is_admin` truthy on the host's User model). Skips
+     * the check when neither column exists, matching formPayload()'s fallback.
+     */
+    protected function agentRoleRule(string $userModel, string $userKey, array $roleColumns): \Closure
+    {
+        return function ($attribute, $value, $fail) use ($userModel, $userKey, $roleColumns): void {
+            if ($roleColumns === []) {
+                return;
+            }
+
+            $user = $userModel::query()->where($userKey, $value)->first();
+            if ($user === null) {
+                return; // Rule::exists already reports this; avoid duplicate failure.
+            }
+
+            foreach ($roleColumns as $column) {
+                if (! empty($user->{$column})) {
+                    return;
+                }
+            }
+
+            $fail('The selected '.$attribute.' is not an agent.');
+        };
+    }
+
+    /**
+     * Which user-role columns exist on the host's users table (intersection of
+     * what we recognise and what is present). Matches formPayload()'s probe.
+     */
+    protected function userRoleColumns(string $userTable): array
+    {
+        $columns = Schema::getColumnListing($userTable);
+
+        return array_values(array_intersect(['is_agent', 'is_admin'], $columns));
     }
 
     protected function syncAgents(Skill $skill, array $agents): void

--- a/tests/Feature/Admin/SkillControllerTest.php
+++ b/tests/Feature/Admin/SkillControllerTest.php
@@ -42,6 +42,26 @@ it('creates a skill with agent assignments and routing rules', function () {
     expect($skill->agents()->first()?->pivot?->proficiency)->toBe(5);
 });
 
+it('rejects assigning a user without agent or admin role', function () {
+    $admin = $this->createAdmin();
+    $nonAgent = $this->createTestUser([
+        'email' => 'just-a-user@example.com',
+        'is_agent' => false,
+        'is_admin' => false,
+    ]);
+
+    $this->actingAs($admin)
+        ->post(route('escalated.admin.skills.store'), [
+            'name' => 'Closed Door',
+            'agents' => [
+                ['user_id' => $nonAgent->id, 'proficiency' => 3],
+            ],
+        ])
+        ->assertSessionHasErrors('agents.0.user_id');
+
+    expect(Skill::query()->where('name', 'Closed Door')->exists())->toBeFalse();
+});
+
 it('updates skill routing rules and re-syncs agent proficiencies', function () {
     $admin = $this->createAdmin();
     $agentOne = $this->createAgent(['email' => 'skill-agent-1@example.com']);


### PR DESCRIPTION
## Summary
Post-merge review of #95 surfaced two HIGH-severity issues that this PR fixes.

1. **`store()` / `update()` not transactional.** A failure in \`syncAgents()\` could leave the skill row updated (name + routing JSON) while \`agent_skill\` rows were partially-rewritten or untouched. Both methods are now wrapped in \`DB::transaction\`.

2. **\`agents.*.user_id\` validation didn't enforce agent role.** Validation only checked the user exists, but \`formPayload()\` filters \`availableAgents\` to users with \`is_agent\` or \`is_admin\` truthy. A crafted request could persist skill assignments for arbitrary users. Validation now matches the same role filter. When the host's \`users\` table has neither column the check is skipped so behaviour stays unchanged for hosts that haven't adopted the convention.

New regression test (\`it rejects assigning a user without agent or admin role\`) covers the role branch.

## Verification
- \`vendor/bin/pest tests/Feature/Admin/SkillControllerTest.php tests/Unit/SkillRoutingServiceTest.php\` — 6 passed
- \`vendor/bin/pint --test src/Http/Controllers/Admin/SkillController.php tests/Feature/Admin/SkillControllerTest.php\` — pass

## Test plan
- [ ] Open Admin → Skills → New, assign a regular user (not an agent) via the form — server rejects with a clear error
- [ ] Same flow for Edit — server rejects, skill state unchanged
- [ ] Submit a valid skill, observe the row + agent_skill entries persist atomically (kill the DB mid-write to confirm rollback in a manual test)