### PR TITLE
Add mobile customer and guest API for Flutter

### DIFF
--- a/config/escalated.php
+++ b/config/escalated.php
@@ -242,6 +242,7 @@ return [
         'rate_limit' => env('ESCALATED_API_RATE_LIMIT', 60),
         'token_expiry_days' => null,
         'prefix' => 'support/api/v1',
+        'mobile_prefix' => 'support/api/v1/mobile',
     ],
 
     /*

--- a/routes/mobile-api.php
+++ b/routes/mobile-api.php
@@ -1,0 +1,48 @@
+<?php
+
+use Escalated\Laravel\Http\Controllers\Api\MobileAuthController;
+use Escalated\Laravel\Http\Controllers\Api\MobileGuestTicketController;
+use Escalated\Laravel\Http\Controllers\Api\MobileKnowledgeBaseController;
+use Escalated\Laravel\Http\Controllers\Api\MobileResourceController;
+use Escalated\Laravel\Http\Controllers\Api\MobileTicketController;
+use Escalated\Laravel\Http\Middleware\ApiRateLimit;
+use Escalated\Laravel\Http\Middleware\AuthenticateApiToken;
+use Escalated\Laravel\Http\Middleware\ResolveTicketByReference;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix(config('escalated.api.mobile_prefix', 'support/api/v1/mobile'))
+    ->middleware(ApiRateLimit::class)
+    ->group(function () {
+        Route::post('/auth/login', [MobileAuthController::class, 'login'])->name('escalated.api.mobile.auth.login');
+        Route::post('/auth/register', [MobileAuthController::class, 'register'])->name('escalated.api.mobile.auth.register');
+
+        Route::get('/departments', [MobileResourceController::class, 'departments'])->name('escalated.api.mobile.departments');
+
+        Route::get('/kb/articles', [MobileKnowledgeBaseController::class, 'index'])->name('escalated.api.mobile.kb.index');
+        Route::get('/kb/articles/{slug}', [MobileKnowledgeBaseController::class, 'show'])->name('escalated.api.mobile.kb.show');
+        Route::post('/kb/articles/{slug}/rate', [MobileKnowledgeBaseController::class, 'rate'])->name('escalated.api.mobile.kb.rate');
+        Route::get('/kb/categories', [MobileKnowledgeBaseController::class, 'categories'])->name('escalated.api.mobile.kb.categories');
+
+        Route::post('/guest/tickets', [MobileGuestTicketController::class, 'store'])->name('escalated.api.mobile.guest.tickets.store');
+        Route::get('/guest/tickets/{token}', [MobileGuestTicketController::class, 'show'])->name('escalated.api.mobile.guest.tickets.show');
+        Route::post('/guest/tickets/{token}/replies', [MobileGuestTicketController::class, 'reply'])->name('escalated.api.mobile.guest.tickets.reply');
+
+        Route::middleware(AuthenticateApiToken::class.':customer')->group(function () {
+            Route::post('/auth/logout', [MobileAuthController::class, 'logout'])->name('escalated.api.mobile.auth.logout');
+            Route::post('/auth/refresh', [MobileAuthController::class, 'refresh'])->name('escalated.api.mobile.auth.refresh');
+            Route::post('/auth/validate', [MobileAuthController::class, 'validateToken'])->name('escalated.api.mobile.auth.validate');
+            Route::get('/auth/me', [MobileAuthController::class, 'me'])->name('escalated.api.mobile.auth.me');
+            Route::put('/auth/profile', [MobileAuthController::class, 'updateProfile'])->name('escalated.api.mobile.auth.profile');
+
+            Route::get('/tickets', [MobileTicketController::class, 'index'])->name('escalated.api.mobile.tickets.index');
+            Route::post('/tickets', [MobileTicketController::class, 'store'])->name('escalated.api.mobile.tickets.store');
+
+            Route::middleware(ResolveTicketByReference::class)->group(function () {
+                Route::get('/tickets/{ticket}', [MobileTicketController::class, 'show'])->name('escalated.api.mobile.tickets.show');
+                Route::post('/tickets/{ticket}/replies', [MobileTicketController::class, 'reply'])->name('escalated.api.mobile.tickets.reply');
+                Route::post('/tickets/{ticket}/close', [MobileTicketController::class, 'close'])->name('escalated.api.mobile.tickets.close');
+                Route::post('/tickets/{ticket}/reopen', [MobileTicketController::class, 'reopen'])->name('escalated.api.mobile.tickets.reopen');
+                Route::post('/tickets/{ticket}/rate', [MobileTicketController::class, 'rate'])->name('escalated.api.mobile.tickets.rate');
+            });
+        });
+    });

--- a/src/EscalatedServiceProvider.php
+++ b/src/EscalatedServiceProvider.php
@@ -272,6 +272,7 @@ class EscalatedServiceProvider extends ServiceProvider
         // REST API routes (token auth, no session)
         if (config('escalated.api.enabled', false)) {
             $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
+            $this->loadRoutesFrom(__DIR__.'/../routes/mobile-api.php');
             $this->registerApiTokenRoutes();
         }
 

--- a/src/Http/Controllers/Api/MobileAuthController.php
+++ b/src/Http/Controllers/Api/MobileAuthController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Api;
+
+use Escalated\Laravel\Escalated;
+use Escalated\Laravel\Http\Resources\MobileUserResource;
+use Escalated\Laravel\Models\ApiToken;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
+
+class MobileAuthController extends Controller
+{
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $userModel = Escalated::userModel();
+        /** @var Model|null $user */
+        $user = $userModel::query()->where('email', $validated['email'])->first();
+
+        if (! $user || ! Hash::check($validated['password'], (string) $user->getAttribute('password'))) {
+            return response()->json(['message' => 'Invalid credentials.'], 422);
+        }
+
+        return $this->tokenResponse($user, 'Mobile Login');
+    }
+
+    public function register(Request $request): JsonResponse
+    {
+        $userModel = Escalated::userModel();
+        $userTable = (new $userModel)->getTable();
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', Rule::unique($userTable, 'email')],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        /** @var Model $user */
+        $user = new $userModel;
+        $user->forceFill([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+        $user->save();
+
+        return $this->tokenResponse($user, 'Mobile Registration', 201);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        /** @var ApiToken|null $apiToken */
+        $apiToken = $request->attributes->get('api_token');
+        $apiToken?->delete();
+
+        return response()->json(['message' => 'Logged out.']);
+    }
+
+    public function refresh(Request $request): JsonResponse
+    {
+        /** @var ApiToken $apiToken */
+        $apiToken = $request->attributes->get('api_token');
+        $user = $request->user();
+
+        $abilities = $apiToken->abilities ?? ['customer'];
+        $apiToken->delete();
+
+        return $this->tokenResponse($user, 'Mobile Refresh', 200, $abilities);
+    }
+
+    public function validateToken(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => new MobileUserResource($request->user()),
+        ]);
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => new MobileUserResource($request->user()),
+        ]);
+    }
+
+    public function updateProfile(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $userTable = $user->getTable();
+
+        $validated = $request->validate([
+            'name' => ['sometimes', 'string', 'max:255'],
+            'email' => ['sometimes', 'email', 'max:255', Rule::unique($userTable, 'email')->ignore($user->getKey())],
+        ]);
+
+        $user->fill($validated);
+        $user->save();
+
+        return response()->json([
+            'data' => new MobileUserResource($user->fresh()),
+        ]);
+    }
+
+    protected function tokenResponse(mixed $user, string $tokenName, int $status = 200, array $abilities = ['customer']): JsonResponse
+    {
+        $expiryDays = config('escalated.api.token_expiry_days');
+        $expiresAt = is_numeric($expiryDays) ? now()->addDays((int) $expiryDays) : null;
+        $token = ApiToken::createToken($user, $tokenName, $abilities, $expiresAt);
+
+        return response()->json([
+            'token' => $token['plainTextToken'],
+            'user' => new MobileUserResource($user),
+            'data' => [
+                'token' => $token['plainTextToken'],
+                'user' => new MobileUserResource($user),
+            ],
+        ], $status);
+    }
+}

--- a/src/Http/Controllers/Api/MobileGuestTicketController.php
+++ b/src/Http/Controllers/Api/MobileGuestTicketController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Api;
+
+use Escalated\Laravel\Enums\TicketPriority;
+use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Http\Resources\MobileTicketResource;
+use Escalated\Laravel\Models\Contact;
+use Escalated\Laravel\Models\EscalatedSettings;
+use Escalated\Laravel\Models\Reply;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Services\AttachmentService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
+
+class MobileGuestTicketController extends Controller
+{
+    public function __construct(protected AttachmentService $attachmentService) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        if (! EscalatedSettings::guestTicketsEnabled()) {
+            return response()->json(['message' => 'Guest tickets are not enabled.'], 403);
+        }
+
+        $maxSize = config('escalated.tickets.max_attachment_size_kb', 10240);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255'],
+            'subject' => ['required', 'string', 'max:255'],
+            'description' => ['required', 'string'],
+            'priority' => ['nullable', 'in:low,medium,high,urgent,critical'],
+            'department_id' => ['nullable', 'exists:'.config('escalated.table_prefix', 'escalated_').'departments,id'],
+            'attachments' => ['nullable', 'array'],
+            'attachments.*' => ['file', 'max:'.$maxSize],
+        ]);
+
+        $contact = Contact::findOrCreateByEmail($validated['email'], $validated['name']);
+        $token = Str::random(64);
+
+        $ticket = Ticket::create([
+            'guest_name' => $validated['name'],
+            'guest_email' => $validated['email'],
+            'guest_token' => $token,
+            'contact_id' => $contact->id,
+            'subject' => $validated['subject'],
+            'description' => $validated['description'],
+            'status' => TicketStatus::Open,
+            'priority' => TicketPriority::tryFrom($validated['priority'] ?? '') ?? TicketPriority::from(config('escalated.default_priority', 'medium')),
+            'channel' => 'web',
+            'department_id' => $validated['department_id'] ?? null,
+        ]);
+
+        if ($request->hasFile('attachments')) {
+            $this->attachmentService->storeMany($ticket, $request->file('attachments', []));
+        }
+
+        $ticket->load(['department', 'attachments']);
+
+        return response()->json([
+            'data' => new MobileTicketResource($ticket, $token),
+            'message' => 'Ticket created.',
+        ], 201);
+    }
+
+    public function show(string $token): JsonResponse
+    {
+        $ticket = Ticket::query()
+            ->where('guest_token', $token)
+            ->firstOrFail();
+
+        $ticket->load([
+            'replies' => fn ($query) => $query->where('is_internal_note', false)->with('author', 'attachments')->latest(),
+            'attachments',
+            'department',
+            'satisfactionRating',
+        ]);
+
+        return response()->json([
+            'data' => new MobileTicketResource($ticket, $token),
+        ]);
+    }
+
+    public function reply(string $token, Request $request): JsonResponse
+    {
+        $ticket = Ticket::query()->where('guest_token', $token)->firstOrFail();
+
+        if ($ticket->status === TicketStatus::Closed) {
+            return response()->json(['message' => 'This ticket is closed.'], 422);
+        }
+
+        $validated = $request->validate([
+            'body' => ['required', 'string'],
+            'email' => ['required', 'email'],
+            'attachments' => ['nullable', 'array'],
+            'attachments.*' => ['file', 'max:'.config('escalated.tickets.max_attachment_size_kb', 10240)],
+        ]);
+
+        if (! hash_equals((string) $ticket->guest_email, (string) $validated['email'])) {
+            return response()->json(['message' => 'The provided email does not match this ticket.'], 403);
+        }
+
+        $reply = new Reply;
+        $reply->ticket_id = $ticket->id;
+        $reply->author_type = null;
+        $reply->author_id = null;
+        $reply->body = $validated['body'];
+        $reply->is_internal_note = false;
+        $reply->type = 'reply';
+        $reply->save();
+
+        if ($request->hasFile('attachments')) {
+            $this->attachmentService->storeMany($reply, $request->file('attachments', []));
+        }
+
+        return response()->json([
+            'message' => 'Reply sent.',
+        ], 201);
+    }
+}

--- a/src/Http/Controllers/Api/MobileKnowledgeBaseController.php
+++ b/src/Http/Controllers/Api/MobileKnowledgeBaseController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Api;
+
+use Escalated\Laravel\Http\Resources\MobileArticleResource;
+use Escalated\Laravel\Models\Article;
+use Escalated\Laravel\Models\ArticleCategory;
+use Escalated\Laravel\Models\EscalatedSettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class MobileKnowledgeBaseController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $this->ensureKnowledgeBaseAccessible();
+
+        $query = Article::published()->with('category');
+
+        if ($request->filled('search')) {
+            $query->search($request->string('search')->toString());
+        }
+
+        if ($request->filled('category_id')) {
+            $query->where('category_id', $request->integer('category_id'));
+        }
+
+        $articles = $query->latest('published_at')->paginate((int) $request->input('per_page', 15));
+
+        return response()->json([
+            'data' => $articles->getCollection()
+                ->map(fn (Article $article) => (new MobileArticleResource($article))->toArray($request))
+                ->values(),
+            'meta' => [
+                'current_page' => $articles->currentPage(),
+                'last_page' => $articles->lastPage(),
+                'per_page' => $articles->perPage(),
+                'total' => $articles->total(),
+            ],
+        ]);
+    }
+
+    public function show(string $slug): JsonResponse
+    {
+        $this->ensureKnowledgeBaseAccessible();
+
+        $article = Article::published()->where('slug', $slug)->firstOrFail();
+        $article->load('category');
+        $article->incrementViews();
+
+        $related = Article::published()
+            ->where('category_id', $article->category_id)
+            ->where('id', '!=', $article->id)
+            ->limit(5)
+            ->get();
+
+        return response()->json([
+            'data' => new MobileArticleResource($article->fresh('category'), $related),
+        ]);
+    }
+
+    public function rate(string $slug, Request $request): JsonResponse
+    {
+        $this->ensureKnowledgeBaseAccessible();
+
+        if (! EscalatedSettings::knowledgeBaseFeedbackEnabled()) {
+            throw new NotFoundHttpException;
+        }
+
+        $validated = $request->validate([
+            'helpful' => ['required', 'boolean'],
+        ]);
+
+        $article = Article::published()->where('slug', $slug)->firstOrFail();
+
+        if ($validated['helpful']) {
+            $article->markHelpful();
+        } else {
+            $article->markNotHelpful();
+        }
+
+        return response()->json(['message' => 'Thank you for your feedback.']);
+    }
+
+    public function categories(): JsonResponse
+    {
+        $this->ensureKnowledgeBaseAccessible();
+
+        $categories = ArticleCategory::query()
+            ->withCount(['articles' => fn ($query) => $query->published()])
+            ->ordered()
+            ->get(['id', 'name', 'slug']);
+
+        return response()->json([
+            'data' => $categories->map(fn (ArticleCategory $category) => [
+                'id' => $category->id,
+                'name' => $category->name,
+                'slug' => $category->slug,
+                'articles_count' => $category->articles_count,
+            ]),
+        ]);
+    }
+
+    protected function ensureKnowledgeBaseAccessible(): void
+    {
+        if (! EscalatedSettings::knowledgeBaseEnabled()) {
+            throw new NotFoundHttpException;
+        }
+    }
+}

--- a/src/Http/Controllers/Api/MobileResourceController.php
+++ b/src/Http/Controllers/Api/MobileResourceController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Api;
+
+use Escalated\Laravel\Models\Department;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+class MobileResourceController extends Controller
+{
+    public function departments(): JsonResponse
+    {
+        $departments = Department::active()
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug']);
+
+        return response()->json([
+            'data' => $departments->map(fn (Department $department) => [
+                'id' => $department->id,
+                'name' => $department->name,
+                'slug' => $department->slug,
+            ]),
+        ]);
+    }
+}

--- a/src/Http/Controllers/Api/MobileTicketController.php
+++ b/src/Http/Controllers/Api/MobileTicketController.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Api;
+
+use Escalated\Laravel\Http\Requests\CreateTicketRequest;
+use Escalated\Laravel\Http\Requests\ReplyToTicketRequest;
+use Escalated\Laravel\Http\Resources\MobileTicketResource;
+use Escalated\Laravel\Models\SatisfactionRating;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Services\TicketService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class MobileTicketController extends Controller
+{
+    public function __construct(protected TicketService $ticketService) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $filters = $request->only(['status', 'priority', 'search', 'per_page']);
+        $filters['per_page'] = min((int) ($filters['per_page'] ?? 15), 100);
+
+        $tickets = $this->ticketService->list($filters, $request->user());
+
+        return response()->json([
+            'data' => $tickets->getCollection()->map(fn (Ticket $ticket) => [
+                'id' => $ticket->id,
+                'reference' => $ticket->reference,
+                'subject' => $ticket->subject,
+                'status' => $ticket->status->value,
+                'status_label' => $ticket->status->label(),
+                'priority' => $ticket->priority->value,
+                'priority_label' => $ticket->priority->label(),
+                'requester' => [
+                    'name' => $ticket->requester_name,
+                    'email' => $ticket->requester_email,
+                ],
+                'assignee' => $ticket->assignee ? [
+                    'id' => $ticket->assignee->getKey(),
+                    'name' => $ticket->assignee->name,
+                ] : null,
+                'department' => $ticket->department ? [
+                    'id' => $ticket->department->id,
+                    'name' => $ticket->department->name,
+                ] : null,
+                'sla_breached' => $ticket->sla_first_response_breached || $ticket->sla_resolution_breached,
+                'last_reply_at' => $ticket->last_reply_at,
+                'created_at' => $ticket->created_at->toIso8601String(),
+                'updated_at' => $ticket->updated_at->toIso8601String(),
+            ])->values(),
+            'meta' => [
+                'current_page' => $tickets->currentPage(),
+                'last_page' => $tickets->lastPage(),
+                'per_page' => $tickets->perPage(),
+                'total' => $tickets->total(),
+            ],
+        ]);
+    }
+
+    public function show(Ticket $ticket, Request $request): JsonResponse
+    {
+        $this->authorizeCustomer($ticket, $request);
+
+        $ticket->load([
+            'replies' => fn ($query) => $query->where('is_internal_note', false)->with('author', 'attachments')->latest(),
+            'attachments',
+            'tags',
+            'department',
+            'assignee',
+            'satisfactionRating',
+        ]);
+
+        return response()->json([
+            'data' => new MobileTicketResource($ticket),
+        ]);
+    }
+
+    public function store(CreateTicketRequest $request): JsonResponse
+    {
+        $ticket = $this->ticketService->create($request->user(), [
+            ...$request->validated(),
+            'channel' => 'web',
+            'attachments' => $request->file('attachments', []),
+        ]);
+
+        $ticket->load(['department', 'tags', 'assignee', 'attachments']);
+
+        return response()->json([
+            'data' => new MobileTicketResource($ticket),
+            'message' => 'Ticket created.',
+        ], 201);
+    }
+
+    public function reply(Ticket $ticket, ReplyToTicketRequest $request): JsonResponse
+    {
+        $this->authorizeCustomer($ticket, $request);
+
+        $this->ticketService->reply(
+            $ticket,
+            $request->user(),
+            $request->validated('body'),
+            $request->file('attachments', [])
+        );
+
+        return response()->json([
+            'message' => 'Reply sent.',
+        ], 201);
+    }
+
+    public function close(Ticket $ticket, Request $request): JsonResponse
+    {
+        $this->authorizeCustomer($ticket, $request);
+
+        if (! config('escalated.tickets.allow_customer_close')) {
+            return response()->json(['message' => 'Customers cannot close this ticket.'], 403);
+        }
+
+        $this->ticketService->close($ticket, $request->user());
+
+        return $this->show($ticket->fresh(), $request);
+    }
+
+    public function reopen(Ticket $ticket, Request $request): JsonResponse
+    {
+        $this->authorizeCustomer($ticket, $request);
+
+        $this->ticketService->reopen($ticket, $request->user());
+
+        return $this->show($ticket->fresh(), $request);
+    }
+
+    public function rate(Ticket $ticket, Request $request): JsonResponse
+    {
+        $this->authorizeCustomer($ticket, $request);
+
+        $validated = $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'comment' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        if (! in_array($ticket->status->value, ['resolved', 'closed'], true)) {
+            return response()->json(['message' => 'You can only rate resolved or closed tickets.'], 422);
+        }
+
+        if ($ticket->satisfactionRating()->exists()) {
+            return response()->json(['message' => 'This ticket has already been rated.'], 422);
+        }
+
+        SatisfactionRating::create([
+            'ticket_id' => $ticket->id,
+            'rating' => $validated['rating'],
+            'comment' => $validated['comment'] ?? null,
+            'rated_by_type' => $request->user()->getMorphClass(),
+            'rated_by_id' => $request->user()->getKey(),
+        ]);
+
+        return response()->json(['message' => 'Thank you for your feedback.']);
+    }
+
+    protected function authorizeCustomer(Ticket $ticket, Request $request): void
+    {
+        if ($ticket->requester_type !== $request->user()->getMorphClass()
+            || $ticket->requester_id !== $request->user()->getKey()) {
+            abort(403);
+        }
+    }
+}

--- a/src/Http/Middleware/AuthenticateApiToken.php
+++ b/src/Http/Middleware/AuthenticateApiToken.php
@@ -56,16 +56,17 @@ class AuthenticateApiToken
             return response()->json(['message' => 'Token owner not found.'], 401);
         }
 
-        // Verify the user still has the required gate permission
-        $agentGate = config('escalated.authorization.agent_gate', 'escalated-agent');
-        if (! Gate::forUser($user)->allows($agentGate)) {
-            Log::warning('API authentication failed: user no longer has agent access', [
-                'token_id' => $apiToken->id,
-                'user_id' => $user->getKey(),
-                'ip' => $request->ip(),
-            ]);
+        if (in_array($ability, ['agent', 'admin'], true)) {
+            $agentGate = config('escalated.authorization.agent_gate', 'escalated-agent');
+            if (! Gate::forUser($user)->allows($agentGate)) {
+                Log::warning('API authentication failed: user no longer has agent access', [
+                    'token_id' => $apiToken->id,
+                    'user_id' => $user->getKey(),
+                    'ip' => $request->ip(),
+                ]);
 
-            return response()->json(['message' => 'User no longer has agent access.'], 403);
+                return response()->json(['message' => 'User no longer has agent access.'], 403);
+            }
         }
 
         if ($ability === 'admin') {

--- a/src/Http/Resources/MobileArticleResource.php
+++ b/src/Http/Resources/MobileArticleResource.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Escalated\Laravel\Http\Resources;
+
+use Escalated\Laravel\Models\Article;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class MobileArticleResource extends JsonResource
+{
+    public function __construct($resource, protected ?Collection $relatedArticles = null)
+    {
+        parent::__construct($resource);
+    }
+
+    public function toArray(Request $request): array
+    {
+        /** @var Article $article */
+        $article = $this->resource;
+
+        return [
+            'id' => $article->id,
+            'title' => $article->title,
+            'slug' => $article->slug,
+            'excerpt' => Str::limit(strip_tags((string) $article->body), 160),
+            'body' => $article->body,
+            'category' => $article->category ? [
+                'id' => $article->category->id,
+                'name' => $article->category->name,
+                'slug' => $article->category->slug,
+            ] : null,
+            'views' => $article->view_count,
+            'helpful_count' => $article->helpful_count,
+            'not_helpful_count' => $article->not_helpful_count,
+            'is_published' => $article->status === 'published',
+            'related_articles' => ($this->relatedArticles ?? collect())
+                ->map(fn (Article $related) => [
+                    'id' => $related->id,
+                    'title' => $related->title,
+                    'slug' => $related->slug,
+                    'excerpt' => Str::limit(strip_tags((string) $related->body), 160),
+                    'created_at' => $related->created_at->toIso8601String(),
+                    'updated_at' => $related->updated_at->toIso8601String(),
+                    'views' => $related->view_count,
+                    'helpful_count' => $related->helpful_count,
+                    'not_helpful_count' => $related->not_helpful_count,
+                    'is_published' => $related->status === 'published',
+                ])
+                ->values(),
+            'published_at' => $article->published_at?->toIso8601String(),
+            'created_at' => $article->created_at->toIso8601String(),
+            'updated_at' => $article->updated_at->toIso8601String(),
+        ];
+    }
+}

--- a/src/Http/Resources/MobileTicketResource.php
+++ b/src/Http/Resources/MobileTicketResource.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Escalated\Laravel\Http\Resources;
+
+use Escalated\Laravel\Models\Reply;
+use Escalated\Laravel\Models\Ticket;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MobileTicketResource extends JsonResource
+{
+    public function __construct($resource, protected ?string $guestAccessToken = null)
+    {
+        parent::__construct($resource);
+    }
+
+    public function toArray(Request $request): array
+    {
+        /** @var Ticket $ticket */
+        $ticket = $this->resource;
+
+        return [
+            'id' => $ticket->id,
+            'reference' => $ticket->reference,
+            'guest_access_token' => $this->guestAccessToken,
+            'subject' => $ticket->subject,
+            'description' => $ticket->description ?? '',
+            'status' => [
+                'value' => $ticket->status->value,
+                'label' => $ticket->status->label(),
+            ],
+            'priority' => [
+                'value' => $ticket->priority->value,
+                'label' => $ticket->priority->label(),
+            ],
+            'channel' => $ticket->channel->value,
+            'metadata' => $ticket->metadata ?? [],
+            'requester' => [
+                'name' => $ticket->requester_name,
+                'email' => $ticket->requester_email,
+            ],
+            'assignee' => $ticket->assignee ? [
+                'id' => $ticket->assignee->getKey(),
+                'name' => $ticket->assignee->name,
+                'email' => $ticket->assignee->email,
+            ] : null,
+            'department' => $ticket->department ? [
+                'id' => $ticket->department->id,
+                'name' => $ticket->department->name,
+            ] : null,
+            'tags' => $ticket->relationLoaded('tags')
+                ? $ticket->tags->map(fn ($tag) => [
+                    'id' => $tag->id,
+                    'name' => $tag->name,
+                    'color' => $tag->color,
+                ])->values()
+                : [],
+            'replies' => $ticket->relationLoaded('replies')
+                ? $ticket->replies->map(fn (Reply $reply) => [
+                    'id' => $reply->id,
+                    'body' => $reply->body,
+                    'is_internal_note' => $reply->is_internal_note,
+                    'is_pinned' => $reply->is_pinned ?? false,
+                    'author' => [
+                        'id' => $reply->author?->getKey() ?? 0,
+                        'name' => $reply->author?->name ?? $ticket->guest_name ?? 'Guest',
+                        'email' => $reply->author?->email ?? $ticket->guest_email ?? '',
+                    ],
+                    'attachments' => $reply->relationLoaded('attachments')
+                        ? $reply->attachments->map(fn ($attachment) => [
+                            'id' => $attachment->id,
+                            'filename' => $attachment->filename,
+                            'mime_type' => $attachment->mime_type,
+                            'size' => $attachment->size,
+                            'url' => $attachment->url,
+                        ])->values()
+                        : [],
+                    'created_at' => $reply->created_at->toIso8601String(),
+                ])->values()
+                : [],
+            'activities' => [],
+            'sla' => [
+                'first_response_due_at' => $ticket->first_response_due_at?->toIso8601String(),
+                'first_response_at' => $ticket->first_response_at?->toIso8601String(),
+                'first_response_breached' => (bool) $ticket->sla_first_response_breached,
+                'resolution_due_at' => $ticket->resolution_due_at?->toIso8601String(),
+                'resolution_breached' => (bool) $ticket->sla_resolution_breached,
+            ],
+            'is_following' => false,
+            'followers_count' => 0,
+            'resolved_at' => $ticket->resolved_at?->toIso8601String(),
+            'closed_at' => $ticket->closed_at?->toIso8601String(),
+            'created_at' => $ticket->created_at->toIso8601String(),
+            'updated_at' => $ticket->updated_at->toIso8601String(),
+        ];
+    }
+}

--- a/src/Http/Resources/MobileUserResource.php
+++ b/src/Http/Resources/MobileUserResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Escalated\Laravel\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MobileUserResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->getKey(),
+            'name' => (string) $this->name,
+            'email' => (string) $this->email,
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/tests/Feature/Api/MobileAuthenticationTest.php
+++ b/tests/Feature/Api/MobileAuthenticationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Escalated\Laravel\Models\ApiToken;
+use Escalated\Laravel\Tests\Fixtures\TestUser;
+
+it('registers a customer and returns a mobile token payload', function () {
+    $this->postJson('/support/api/v1/mobile/auth/register', [
+        'name' => 'Customer One',
+        'email' => 'customer1@example.com',
+        'password' => 'password123',
+        'password_confirmation' => 'password123',
+    ])->assertStatus(201)
+        ->assertJsonPath('user.email', 'customer1@example.com')
+        ->assertJsonPath('data.user.name', 'Customer One');
+
+    expect(TestUser::where('email', 'customer1@example.com')->exists())->toBeTrue();
+});
+
+it('logs a customer in and validates the mobile token', function () {
+    $user = TestUser::create([
+        'name' => 'Existing Customer',
+        'email' => 'existing@example.com',
+        'password' => bcrypt('password123'),
+    ]);
+
+    $login = $this->postJson('/support/api/v1/mobile/auth/login', [
+        'email' => 'existing@example.com',
+        'password' => 'password123',
+    ])->assertOk()
+        ->json();
+
+    $token = $login['token'];
+
+    $this->postJson('/support/api/v1/mobile/auth/validate', [], [
+        'Authorization' => 'Bearer '.$token,
+    ])->assertOk()
+        ->assertJsonPath('data.email', 'existing@example.com');
+});
+
+it('refreshes and revokes the previous mobile token', function () {
+    $user = TestUser::create([
+        'name' => 'Refresh Customer',
+        'email' => 'refresh@example.com',
+        'password' => bcrypt('password123'),
+    ]);
+
+    $result = ApiToken::createToken($user, 'Mobile Login', ['customer']);
+
+    $refresh = $this->postJson('/support/api/v1/mobile/auth/refresh', [], [
+        'Authorization' => 'Bearer '.$result['plainTextToken'],
+    ])->assertOk()
+        ->json();
+
+    $this->postJson('/support/api/v1/mobile/auth/validate', [], [
+        'Authorization' => 'Bearer '.$result['plainTextToken'],
+    ])->assertStatus(401);
+
+    $this->postJson('/support/api/v1/mobile/auth/validate', [], [
+        'Authorization' => 'Bearer '.$refresh['token'],
+    ])->assertOk()
+        ->assertJsonPath('data.email', 'refresh@example.com');
+});

--- a/tests/Feature/Api/MobileKnowledgeBaseTest.php
+++ b/tests/Feature/Api/MobileKnowledgeBaseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Escalated\Laravel\Models\Article;
+use Escalated\Laravel\Models\ArticleCategory;
+use Escalated\Laravel\Models\EscalatedSettings;
+
+it('lists mobile knowledge base articles and categories', function () {
+    EscalatedSettings::set('knowledge_base_enabled', 'true');
+    EscalatedSettings::set('knowledge_base_public', 'true');
+
+    $category = ArticleCategory::create([
+        'name' => 'Billing',
+        'slug' => 'billing',
+    ]);
+
+    Article::create([
+        'category_id' => $category->id,
+        'title' => 'How billing works',
+        'slug' => 'how-billing-works',
+        'body' => '<p>Billing details</p>',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->getJson('/support/api/v1/mobile/kb/articles')
+        ->assertOk()
+        ->assertJsonPath('data.0.slug', 'how-billing-works');
+
+    $this->getJson('/support/api/v1/mobile/kb/categories')
+        ->assertOk()
+        ->assertJsonPath('data.0.slug', 'billing');
+});
+
+it('shows a mobile knowledge base article and records feedback', function () {
+    EscalatedSettings::set('knowledge_base_enabled', 'true');
+    EscalatedSettings::set('knowledge_base_public', 'true');
+    EscalatedSettings::set('knowledge_base_feedback_enabled', 'true');
+
+    $article = Article::create([
+        'title' => 'Driver payout schedule',
+        'slug' => 'driver-payout-schedule',
+        'body' => '<p>Weekly payouts</p>',
+        'status' => 'published',
+        'published_at' => now(),
+    ]);
+
+    $this->getJson('/support/api/v1/mobile/kb/articles/driver-payout-schedule')
+        ->assertOk()
+        ->assertJsonPath('data.slug', 'driver-payout-schedule');
+
+    $this->postJson('/support/api/v1/mobile/kb/articles/driver-payout-schedule/rate', [
+        'helpful' => true,
+    ])->assertOk();
+
+    expect($article->fresh()->helpful_count)->toBe(1);
+});

--- a/tests/Feature/Api/MobileTicketTest.php
+++ b/tests/Feature/Api/MobileTicketTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Escalated\Laravel\Enums\TicketPriority;
+use Escalated\Laravel\Enums\TicketStatus;
+use Escalated\Laravel\Models\ApiToken;
+use Escalated\Laravel\Models\Department;
+use Escalated\Laravel\Models\EscalatedSettings;
+use Escalated\Laravel\Models\SatisfactionRating;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Tests\Fixtures\TestUser;
+
+function mobileCustomer(array $attributes = []): array
+{
+    $user = TestUser::create(array_merge([
+        'name' => 'Mobile Customer',
+        'email' => 'mobile-'.uniqid().'@example.com',
+        'password' => bcrypt('password123'),
+    ], $attributes));
+
+    $result = ApiToken::createToken($user, 'Mobile Token', ['customer']);
+
+    return [
+        'user' => $user,
+        'headers' => ['Authorization' => 'Bearer '.$result['plainTextToken']],
+    ];
+}
+
+it('lists only the authenticated customers tickets in the mobile api', function () {
+    $customer = mobileCustomer();
+    $other = mobileCustomer();
+
+    Ticket::create([
+        'reference' => 'ESC-10101',
+        'requester_type' => $customer['user']->getMorphClass(),
+        'requester_id' => $customer['user']->getKey(),
+        'subject' => 'My Ticket',
+        'description' => 'Mine',
+        'status' => TicketStatus::Open,
+        'priority' => TicketPriority::Medium,
+    ]);
+
+    Ticket::create([
+        'reference' => 'ESC-10102',
+        'requester_type' => $other['user']->getMorphClass(),
+        'requester_id' => $other['user']->getKey(),
+        'subject' => 'Other Ticket',
+        'description' => 'Not mine',
+        'status' => TicketStatus::Open,
+        'priority' => TicketPriority::Medium,
+    ]);
+
+    $this->getJson('/support/api/v1/mobile/tickets', $customer['headers'])
+        ->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.reference', 'ESC-10101');
+});
+
+it('creates, replies to, closes, reopens, and rates a customer ticket in the mobile api', function () {
+    $customer = mobileCustomer();
+    $department = Department::create([
+        'name' => 'Support',
+        'slug' => 'support',
+        'is_active' => true,
+    ]);
+
+    $created = $this->postJson('/support/api/v1/mobile/tickets', [
+        'subject' => 'Payout missing',
+        'description' => 'I need help with a payout.',
+        'priority' => 'high',
+        'department_id' => $department->id,
+    ], $customer['headers'])->assertStatus(201)->json();
+
+    $reference = $created['data']['reference'];
+
+    $this->postJson("/support/api/v1/mobile/tickets/{$reference}/replies", [
+        'body' => 'Here is more detail.',
+    ], $customer['headers'])->assertStatus(201);
+
+    $this->getJson("/support/api/v1/mobile/tickets/{$reference}", $customer['headers'])
+        ->assertOk()
+        ->assertJsonPath('data.subject', 'Payout missing')
+        ->assertJsonPath('data.status.value', 'open')
+        ->assertJsonPath('data.replies.0.body', 'Here is more detail.');
+
+    $this->postJson("/support/api/v1/mobile/tickets/{$reference}/close", [], $customer['headers'])
+        ->assertOk()
+        ->assertJsonPath('data.status.value', 'closed');
+
+    $this->postJson("/support/api/v1/mobile/tickets/{$reference}/reopen", [], $customer['headers'])
+        ->assertOk()
+        ->assertJsonPath('data.status.value', 'reopened');
+
+    Ticket::where('reference', $reference)->update([
+        'status' => TicketStatus::Resolved->value,
+        'resolved_at' => now(),
+    ]);
+
+    $this->postJson("/support/api/v1/mobile/tickets/{$reference}/rate", [
+        'rating' => 5,
+        'comment' => 'Resolved quickly.',
+    ], $customer['headers'])->assertOk();
+
+    expect(SatisfactionRating::query()->whereHas('ticket', fn ($query) => $query->where('reference', $reference))->exists())->toBeTrue();
+});
+
+it('supports guest ticket creation and guest replies in the mobile api', function () {
+    EscalatedSettings::set('guest_tickets_enabled', 'true');
+
+    $created = $this->postJson('/support/api/v1/mobile/guest/tickets', [
+        'name' => 'Guest Rider',
+        'email' => 'guest@example.com',
+        'subject' => 'Need help',
+        'description' => 'I cannot track my order.',
+        'priority' => 'medium',
+    ])->assertStatus(201)->json();
+
+    $guestToken = $created['data']['guest_access_token'];
+
+    $this->getJson("/support/api/v1/mobile/guest/tickets/{$guestToken}")
+        ->assertOk()
+        ->assertJsonPath('data.reference', 'ESC-00001');
+
+    $this->postJson("/support/api/v1/mobile/guest/tickets/{$guestToken}/replies", [
+        'email' => 'guest@example.com',
+        'body' => 'Additional information',
+    ])->assertStatus(201);
+
+    $this->getJson("/support/api/v1/mobile/guest/tickets/{$guestToken}")
+        ->assertOk()
+        ->assertJsonPath('data.replies.0.body', 'Additional information');
+});


### PR DESCRIPTION
## Summary
- add a dedicated mobile API under /support/api/v1/mobile
- add customer auth, ticket, guest ticket, knowledge base, and department endpoints
- add Pest coverage for the new mobile contract

## Verification
- php vendor/bin/pint --dirty --format=agent
- php vendor/bin/pest --compact tests/Feature/Api/MobileAuthenticationTest.php tests/Feature/Api/MobileKnowledgeBaseTest.php tests/Feature/Api/MobileTicketTest.php