### PR TITLE
fix(users): support UUID/string host user keys throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Support UUID/string host-app user keys throughout. `SavedView::scopeForUser()` (and every other user-id parameter) now accepts `int|string` instead of hard-typing `int`, fixing a `TypeError` 500 (`Argument #2 ($userId) must be of type int, string given`) that hit apps with non-integer user keys when opening `/support/admin/tickets`. Incoming user ids are no longer cast to `int` anywhere (which corrupted UUIDs). See the README "UUID / string user keys" note for matching the package's user-referencing columns. (#109)
+
 ### Added
 - Consume translation strings from the shared `escalated-dev/locale` Composer package so wording stays consistent across every Escalated host plugin. The `EscalatedServiceProvider` now stitches three layers under the `escalated` namespace: the central package (canonical), `lang/vendor/escalated/` in this repository (Laravel-specific overrides), and the host app's `lang/vendor/escalated/` (consumer overrides via `php artisan vendor:publish --tag=escalated-lang`). The package's own `resources/lang/` is retained as a fallback for environments where the central package has not yet been composer-installed.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Gate::define('escalated-agent', fn ($user) => $user->is_agent);
 
 Visit `/support` — you're live.
 
+### UUID / string user keys
+
+Escalated accepts both integer and string (UUID/ULID) host-app user keys — every
+user-id parameter is typed `int|string` and incoming user ids are never cast to
+`int`. If your `User` model uses a non-integer primary key, also make sure the
+package's user-referencing columns match. The columns Escalated creates for host
+users (`escalated_ticket_followers.user_id`, `escalated_agent_profiles.user_id`,
+`escalated_tickets.assigned_to` / `requester_id`, the role and skill pivots, etc.)
+default to `unsignedBigInteger`. Publish the migrations
+(`php artisan vendor:publish --tag=escalated-migrations`) and change those columns
+to `uuid`/`string` to match your user table before migrating.
+
 ## Frontend Integration
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.

--- a/src/Contracts/TicketDriver.php
+++ b/src/Contracts/TicketDriver.php
@@ -16,7 +16,7 @@ interface TicketDriver
 
     public function transitionStatus(Ticket $ticket, TicketStatus $status, ?Ticketable $causer = null): Ticket;
 
-    public function assignTicket(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket;
+    public function assignTicket(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket;
 
     public function unassignTicket(Ticket $ticket, ?Ticketable $causer = null): Ticket;
 

--- a/src/Drivers/CloudDriver.php
+++ b/src/Drivers/CloudDriver.php
@@ -45,7 +45,7 @@ class CloudDriver implements TicketDriver
         return $this->hydrateTicket($response);
     }
 
-    public function assignTicket(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket
+    public function assignTicket(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket
     {
         $response = $this->apiClient->sendCommand('tickets.assign', [
             'reference' => $ticket->reference,

--- a/src/Drivers/LocalDriver.php
+++ b/src/Drivers/LocalDriver.php
@@ -81,7 +81,7 @@ class LocalDriver implements TicketDriver
         return $ticket->transitionTo($newStatus, $causer);
     }
 
-    public function assignTicket(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket
+    public function assignTicket(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket
     {
         return $ticket->assign($agentId, $causer);
     }

--- a/src/Drivers/SyncedDriver.php
+++ b/src/Drivers/SyncedDriver.php
@@ -49,7 +49,7 @@ class SyncedDriver extends LocalDriver
         return $ticket;
     }
 
-    public function assignTicket(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket
+    public function assignTicket(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket
     {
         $ticket = parent::assignTicket($ticket, $agentId, $causer);
         $this->syncEvent('ticket.assigned', ['ticket' => $ticket->toArray(), 'agent_id' => $agentId]);

--- a/src/Events/TicketAssigned.php
+++ b/src/Events/TicketAssigned.php
@@ -15,7 +15,7 @@ class TicketAssigned implements ShouldBroadcastNow
 
     public function __construct(
         public Ticket $ticket,
-        public int $agentId,
+        public int|string $agentId,
         public mixed $causer = null,
     ) {}
 

--- a/src/Http/Controllers/Admin/PublicTicketsSettingsController.php
+++ b/src/Http/Controllers/Admin/PublicTicketsSettingsController.php
@@ -64,7 +64,7 @@ class PublicTicketsSettingsController extends Controller
 
         return [
             'guest_policy_mode' => EscalatedSettings::get('guest_policy_mode', 'unassigned'),
-            'guest_policy_user_id' => $userIdRaw === '' ? null : (int) $userIdRaw,
+            'guest_policy_user_id' => $userIdRaw === '' ? null : $userIdRaw,
             'guest_policy_signup_url_template' => EscalatedSettings::get(
                 'guest_policy_signup_url_template',
                 ''

--- a/src/Http/Controllers/Admin/SkillController.php
+++ b/src/Http/Controllers/Admin/SkillController.php
@@ -179,7 +179,7 @@ class SkillController extends Controller
     {
         $payload = collect($agents)
             ->mapWithKeys(fn (array $agent) => [
-                (int) $agent['user_id'] => ['proficiency' => (int) $agent['proficiency']],
+                $agent['user_id'] => ['proficiency' => (int) $agent['proficiency']],
             ])
             ->all();
 

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -34,7 +34,7 @@ class BulkActionController extends Controller
                 match ($action) {
                     'status' => $this->ticketService->changeStatus($ticket, TicketStatus::from($value), $causer),
                     'priority' => $this->ticketService->changePriority($ticket, TicketPriority::from($value), $causer),
-                    'assign' => $this->assignmentService->assign($ticket, (int) $value, $causer),
+                    'assign' => $this->assignmentService->assign($ticket, $value, $causer),
                     'tags' => $this->ticketService->addTags($ticket, (array) $value, $causer),
                     'department' => $this->ticketService->changeDepartment($ticket, (int) $value, $causer),
                     'delete' => Gate::allows(config('escalated.authorization.admin_gate', 'escalated-admin'), $request->user())

--- a/src/Http/Controllers/WidgetController.php
+++ b/src/Http/Controllers/WidgetController.php
@@ -138,8 +138,8 @@ class WidgetController extends Controller
         $mode = EscalatedSettings::get('guest_policy_mode', 'unassigned');
 
         if ($mode === 'guest_user') {
-            $guestUserId = (int) EscalatedSettings::get('guest_policy_user_id', 0);
-            if ($guestUserId > 0) {
+            $guestUserId = EscalatedSettings::get('guest_policy_user_id');
+            if (! empty($guestUserId)) {
                 $attrs['requester_type'] = config('escalated.user_model', 'App\\Models\\User');
                 $attrs['requester_id'] = $guestUserId;
                 $attrs['guest_name'] = $validated['name'];

--- a/src/Http/Middleware/CheckPermission.php
+++ b/src/Http/Middleware/CheckPermission.php
@@ -25,7 +25,7 @@ class CheckPermission
         abort(403, 'You do not have the required permission: '.$permission);
     }
 
-    protected function userHasPermission(int $userId, string $permissionSlug): bool
+    protected function userHasPermission(int|string $userId, string $permissionSlug): bool
     {
         return DB::table(Escalated::table('role_user'))
             ->join(Escalated::table('role_permission'), Escalated::table('role_user').'.role_id', '=', Escalated::table('role_permission').'.role_id')

--- a/src/Models/AgentProfile.php
+++ b/src/Models/AgentProfile.php
@@ -42,7 +42,7 @@ class AgentProfile extends Model
     /**
      * Get or create a profile for a user.
      */
-    public static function forUser(int $userId): self
+    public static function forUser(int|string $userId): self
     {
         return static::firstOrCreate(
             ['user_id' => $userId],

--- a/src/Models/CannedResponse.php
+++ b/src/Models/CannedResponse.php
@@ -36,7 +36,7 @@ class CannedResponse extends Model
         return $query->where('is_shared', true);
     }
 
-    public function scopeForAgent($query, int $agentId)
+    public function scopeForAgent($query, int|string $agentId)
     {
         return $query->where(function ($q) use ($agentId) {
             $q->where('is_shared', true)->orWhere('created_by', $agentId);

--- a/src/Models/ChatSession.php
+++ b/src/Models/ChatSession.php
@@ -60,7 +60,7 @@ class ChatSession extends Model
         return $query->where('status', ChatSessionStatus::Ended->value);
     }
 
-    public function scopeForAgent($query, int $agentId)
+    public function scopeForAgent($query, int|string $agentId)
     {
         return $query->where('agent_id', $agentId);
     }

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -54,7 +54,7 @@ class Contact extends Model
         ]);
     }
 
-    public function linkToUser(int $userId): self
+    public function linkToUser(int|string $userId): self
     {
         $this->user_id = $userId;
         $this->save();
@@ -66,7 +66,7 @@ class Contact extends Model
      * Link to a host-app user and back-stamp requester_id on all
      * prior tickets owned by this contact.
      */
-    public function promoteToUser(int $userId, string $userType = 'App\\Models\\User'): self
+    public function promoteToUser(int|string $userId, string $userType = 'App\\Models\\User'): self
     {
         $this->linkToUser($userId);
         Ticket::where('contact_id', $this->id)->update([

--- a/src/Models/Macro.php
+++ b/src/Models/Macro.php
@@ -33,7 +33,7 @@ class Macro extends Model
         return $query->where('is_shared', true);
     }
 
-    public function scopeForAgent($query, int $agentId)
+    public function scopeForAgent($query, int|string $agentId)
     {
         return $query->where(function ($q) use ($agentId) {
             $q->where('is_shared', true)

--- a/src/Models/SavedView.php
+++ b/src/Models/SavedView.php
@@ -3,6 +3,7 @@
 namespace Escalated\Laravel\Models;
 
 use Escalated\Laravel\Escalated;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -30,7 +31,7 @@ class SavedView extends Model
         return $this->belongsTo(Escalated::userModel(), 'user_id');
     }
 
-    public function scopeForUser($query, int $userId)
+    public function scopeForUser(Builder $query, int|string $userId): Builder
     {
         return $query->where(function ($q) use ($userId) {
             $q->where('user_id', $userId)

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -199,17 +199,17 @@ class Ticket extends Model
         return $this->hasMany(Reply::class, 'ticket_id')->where('is_internal_note', true)->where('is_pinned', true);
     }
 
-    public function isFollowedBy(int $userId): bool
+    public function isFollowedBy(int|string $userId): bool
     {
         return $this->followers()->where('user_id', $userId)->exists();
     }
 
-    public function follow(int $userId): void
+    public function follow(int|string $userId): void
     {
         $this->followers()->syncWithoutDetaching([$userId]);
     }
 
-    public function unfollow(int $userId): void
+    public function unfollow(int|string $userId): void
     {
         $this->followers()->detach($userId);
     }
@@ -226,7 +226,7 @@ class Ticket extends Model
         return $query->whereNull('assigned_to');
     }
 
-    public function scopeAssignedTo($query, int $agentId)
+    public function scopeAssignedTo($query, int|string $agentId)
     {
         return $query->where('assigned_to', $agentId);
     }

--- a/src/Services/AssignmentService.php
+++ b/src/Services/AssignmentService.php
@@ -14,7 +14,7 @@ class AssignmentService
         protected SkillRoutingService $skillRoutingService,
     ) {}
 
-    public function assign(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket
+    public function assign(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket
     {
         return $this->manager->driver()->assignTicket($ticket, $agentId, $causer);
     }
@@ -24,7 +24,7 @@ class AssignmentService
         return $this->manager->driver()->unassignTicket($ticket, $causer);
     }
 
-    public function reassign(Ticket $ticket, int $agentId, ?Ticketable $causer = null): Ticket
+    public function reassign(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket
     {
         return $this->manager->driver()->assignTicket($ticket, $agentId, $causer);
     }
@@ -57,7 +57,7 @@ class AssignmentService
         return $this->assign($ticket, $agentId);
     }
 
-    public function getAgentWorkload(int $agentId): array
+    public function getAgentWorkload(int|string $agentId): array
     {
         return [
             'open' => Ticket::assignedTo($agentId)->open()->count(),

--- a/src/Services/CapacityService.php
+++ b/src/Services/CapacityService.php
@@ -10,7 +10,7 @@ class CapacityService
     /**
      * Check if an agent can accept a new ticket.
      */
-    public function canAcceptTicket(int $userId, string $channel = 'default'): bool
+    public function canAcceptTicket(int|string $userId, string $channel = 'default'): bool
     {
         $capacity = AgentCapacity::firstOrCreate(
             ['user_id' => $userId, 'channel' => $channel],
@@ -23,7 +23,7 @@ class CapacityService
     /**
      * Increment the agent's current load.
      */
-    public function incrementLoad(int $userId, string $channel = 'default'): void
+    public function incrementLoad(int|string $userId, string $channel = 'default'): void
     {
         $capacity = AgentCapacity::firstOrCreate(
             ['user_id' => $userId, 'channel' => $channel],
@@ -36,7 +36,7 @@ class CapacityService
     /**
      * Decrement the agent's current load.
      */
-    public function decrementLoad(int $userId, string $channel = 'default'): void
+    public function decrementLoad(int|string $userId, string $channel = 'default'): void
     {
         $capacity = AgentCapacity::firstOrCreate(
             ['user_id' => $userId, 'channel' => $channel],

--- a/src/Services/ChatAvailabilityService.php
+++ b/src/Services/ChatAvailabilityService.php
@@ -47,7 +47,7 @@ class ChatAvailabilityService
     /**
      * Get the number of active chat sessions for a specific agent.
      */
-    public function getAgentChatCount(int $agentId): int
+    public function getAgentChatCount(int|string $agentId): int
     {
         return ChatSession::active()->forAgent($agentId)->count();
     }

--- a/src/Services/ChatRoutingService.php
+++ b/src/Services/ChatRoutingService.php
@@ -119,7 +119,7 @@ class ChatRoutingService
     /**
      * Get the number of active chat sessions for a specific agent.
      */
-    public function getAgentChatCount(int $agentId): int
+    public function getAgentChatCount(int|string $agentId): int
     {
         return ChatSession::active()->forAgent($agentId)->count();
     }

--- a/src/Services/ChatSessionService.php
+++ b/src/Services/ChatSessionService.php
@@ -67,7 +67,7 @@ class ChatSessionService
     /**
      * Assign an agent to a chat session.
      */
-    public function assignAgent(ChatSession $session, int $agentId): void
+    public function assignAgent(ChatSession $session, int|string $agentId): void
     {
         $session->update([
             'agent_id' => $agentId,
@@ -138,7 +138,7 @@ class ChatSessionService
     /**
      * Send a message in a chat session (creates a reply on the ticket).
      */
-    public function sendMessage(ChatSession $session, string $body, ?int $userId, bool $isAgent): Reply
+    public function sendMessage(ChatSession $session, string $body, int|string|null $userId, bool $isAgent): Reply
     {
         $replyData = [
             'ticket_id' => $session->ticket_id,

--- a/src/Services/InboundEmailService.php
+++ b/src/Services/InboundEmailService.php
@@ -281,8 +281,8 @@ class InboundEmailService
 
         $mode = EscalatedSettings::get('guest_policy_mode', 'unassigned');
         if ($mode === 'guest_user') {
-            $guestUserId = (int) EscalatedSettings::get('guest_policy_user_id', 0);
-            if ($guestUserId > 0) {
+            $guestUserId = EscalatedSettings::get('guest_policy_user_id');
+            if (! empty($guestUserId)) {
                 $attrs['requester_type'] = config('escalated.user_model', 'App\\Models\\User');
                 $attrs['requester_id'] = $guestUserId;
             } else {

--- a/src/Services/MacroService.php
+++ b/src/Services/MacroService.php
@@ -24,7 +24,7 @@ class MacroService
             match ($type) {
                 'status' => $this->ticketService->changeStatus($ticket, TicketStatus::from($value), $causer),
                 'priority' => $this->ticketService->changePriority($ticket, TicketPriority::from($value), $causer),
-                'assign' => $this->assignmentService->assign($ticket, (int) $value, $causer),
+                'assign' => $this->assignmentService->assign($ticket, $value, $causer),
                 'tags' => $this->ticketService->addTags($ticket, (array) $value, $causer),
                 'department' => $this->ticketService->changeDepartment($ticket, (int) $value, $causer),
                 'reply' => $this->ticketService->reply($ticket, $causer, $value),

--- a/src/Services/ReportingService.php
+++ b/src/Services/ReportingService.php
@@ -145,7 +145,7 @@ class ReportingService
     /**
      * Get detailed agent metrics for a specific agent.
      */
-    public function getAgentMetrics(int $agentId, Carbon $startDate, Carbon $endDate): array
+    public function getAgentMetrics(int|string $agentId, Carbon $startDate, Carbon $endDate): array
     {
         $avgResponseRaw = $this->avgHoursDiffExpression('created_at', 'first_response_at');
         $avgResolutionRaw = $this->avgHoursDiffExpression('created_at', 'resolved_at');
@@ -667,7 +667,7 @@ class ReportingService
     /**
      * p50, p75, p90, p95, p99 response time percentiles for a specific agent.
      */
-    public function agentResponseTimePercentiles(int $agentId, int $days): array
+    public function agentResponseTimePercentiles(int|string $agentId, int $days): array
     {
         $since = now()->subDays($days);
         $hoursDiff = $this->hoursDiffExpression('created_at', 'first_response_at');

--- a/src/Services/SkillRoutingService.php
+++ b/src/Services/SkillRoutingService.php
@@ -62,7 +62,7 @@ class SkillRoutingService
 
         $userModel = Escalated::userModel();
         $userKey = (new $userModel)->getKeyName();
-        $agentIds = $agentSkillRows->pluck('user_id')->map(fn ($id) => (int) $id)->unique()->values();
+        $agentIds = $agentSkillRows->pluck('user_id')->unique()->values();
 
         $openTicketCounts = Ticket::query()
             ->open()

--- a/tests/Feature/UuidUserIdTest.php
+++ b/tests/Feature/UuidUserIdTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Escalated\Laravel\Models\Mention;
+use Escalated\Laravel\Models\Reply;
+use Escalated\Laravel\Models\SavedView;
+use Escalated\Laravel\Models\Ticket;
+
+// Regression coverage for host apps whose User model uses a UUID/string primary
+// key. The package must accept string user ids throughout without a TypeError.
+
+it('scopes saved views for a string/uuid user id without a type error', function () {
+    $uuid = '9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f';
+    $otherUuid = '00000000-0000-0000-0000-000000000000';
+
+    $mine = SavedView::create([
+        'name' => 'Mine',
+        'user_id' => $uuid,
+        'filters' => ['status' => 'open'],
+        'position' => 1,
+    ]);
+
+    $shared = SavedView::create([
+        'name' => 'Shared',
+        'user_id' => $otherUuid,
+        'filters' => [],
+        'is_shared' => true,
+        'position' => 2,
+    ]);
+
+    SavedView::create([
+        'name' => 'Someone else private',
+        'user_id' => $otherUuid,
+        'filters' => [],
+        'position' => 3,
+    ]);
+
+    $ids = SavedView::forUser($uuid)->pluck('id')->all();
+
+    expect($ids)->toContain($mine->id)
+        ->and($ids)->toContain($shared->id)
+        ->and($ids)->toHaveCount(2);
+});
+
+it('scopes mentions for a string/uuid user id without a type error', function () {
+    $uuid = 'abcdef01-2345-6789-abcd-ef0123456789';
+
+    $ticket = Ticket::factory()->create();
+    $reply = Reply::create([
+        'ticket_id' => $ticket->id,
+        'body' => 'Hey @agent',
+        'is_internal_note' => true,
+        'type' => 'note',
+    ]);
+
+    $mention = Mention::create([
+        'reply_id' => $reply->id,
+        'user_id' => $uuid,
+    ]);
+
+    $found = Mention::forUser($uuid)->pluck('id')->all();
+
+    expect($found)->toContain($mention->id)
+        ->and(Mention::forUser('11111111-1111-1111-1111-111111111111')->count())->toBe(0);
+});


### PR DESCRIPTION
Fixes #109.

## The bug
Host apps whose `User` model uses a UUID/string primary key hit a `TypeError` 500 when opening `/support/admin/tickets`:

```
Escalated\Laravel\Models\SavedView::scopeForUser(): Argument #2 ($userId) must be of type int, string given
```

## The fix
1. **Immediate:** `SavedView::scopeForUser` is now `(\Illuminate\Database\Eloquent\Builder $query, int|string $userId): \Illuminate\Database\Eloquent\Builder` — mirroring `Mention::scopeForUser`, which was already correct.
2. **Audit:** relaxed **every host-user-id parameter/property** across `src/` from `int` to `int|string` — `userId`/`agentId`/`causerId`/`authorId`/`followerId` across models, services, drivers, the `TicketDriver` contract, the `TicketAssigned` event, and `CheckPermission`. Internal Escalated ids (ticket/macro/department/tag/session) stay `int`.
3. **No more int casts on user ids:** removed `(int)` casts that corrupted UUIDs on the bulk-assign, macro-assign, skill agent-sync, skill-routing, and `guest_policy_user_id` (widget + inbound email + settings) paths.
4. **Columns:** added a README **"UUID / string user keys"** note — the package's user-referencing columns default to `unsignedBigInteger`; UUID apps publish the migrations and switch them to `uuid`/`string`. (Kept as documentation rather than a schema change so existing integer-keyed installs aren't broken by a patch.)
5. **Regression test:** `tests/Feature/UuidUserIdTest.php` calls `SavedView::forUser()` and `Mention::forUser()` with UUID strings and asserts correct scoping with no `TypeError` (the SavedView case reproduces #109 — it fails on `main`).

## Testing
- `pest` — new regression test passes; existing `SavedViewTest` + `MentionServiceTest` (21 tests) still pass — type widening is backward-compatible.
- `php -l` clean on all changed files; `pint --test` clean (LF) on changed files.

## Follow-ups
- Tag a patch release after merge.
- Port the same fix to the other host frameworks (NestJS, Rails, Django, etc.) — happy to fan these out next.