### PR TITLE
feat(users): auto-detect host user key type for migration columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Support UUID/string host-app user keys throughout. `SavedView::scopeForUser()` (and every other user-id parameter) now accepts `int|string` instead of hard-typing `int`, fixing a `TypeError` 500 (`Argument #2 ($userId) must be of type int, string given`) that hit apps with non-integer user keys when opening `/support/admin/tickets`. Incoming user ids are no longer cast to `int` anywhere (which corrupted UUIDs). See the README "UUID / string user keys" note for matching the package's user-referencing columns. (#109)
+- Support UUID/string host-app user keys throughout. `SavedView::scopeForUser()` (and every other user-id parameter) now accepts `int|string` instead of hard-typing `int`, fixing a `TypeError` 500 (`Argument #2 ($userId) must be of type int, string given`) that hit apps with non-integer user keys when opening `/support/admin/tickets`. Incoming user ids are no longer cast to `int` anywhere (which corrupted UUIDs). (#109)
 
 ### Added
+- Auto-detect the host user key type for the package's user-referencing migration columns. `Escalated::userForeignColumn()`/`userMorphs()` now type `user_id`/`assigned_to`/`requester`/`author`/`causer`/pivot columns to match the configured `user_model` — `unsignedBigInteger` for integer keys, string-compatible columns for `HasUuids`/`HasUlids`/string keys — so UUID/string-keyed apps migrate cleanly with no manual edits. Override via the new `escalated.user_key_type` config (`auto` by default). (#109)
 - Consume translation strings from the shared `escalated-dev/locale` Composer package so wording stays consistent across every Escalated host plugin. The `EscalatedServiceProvider` now stitches three layers under the `escalated` namespace: the central package (canonical), `lang/vendor/escalated/` in this repository (Laravel-specific overrides), and the host app's `lang/vendor/escalated/` (consumer overrides via `php artisan vendor:publish --tag=escalated-lang`). The package's own `resources/lang/` is retained as a fallback for environments where the central package has not yet been composer-installed.
 
 ## [1.2.1] - 2026-04-18

--- a/README.md
+++ b/README.md
@@ -95,15 +95,30 @@ Visit `/support` — you're live.
 
 ### UUID / string user keys
 
-Escalated accepts both integer and string (UUID/ULID) host-app user keys — every
-user-id parameter is typed `int|string` and incoming user ids are never cast to
-`int`. If your `User` model uses a non-integer primary key, also make sure the
-package's user-referencing columns match. The columns Escalated creates for host
-users (`escalated_ticket_followers.user_id`, `escalated_agent_profiles.user_id`,
-`escalated_tickets.assigned_to` / `requester_id`, the role and skill pivots, etc.)
-default to `unsignedBigInteger`. Publish the migrations
-(`php artisan vendor:publish --tag=escalated-migrations`) and change those columns
-to `uuid`/`string` to match your user table before migrating.
+Escalated supports both integer and string (UUID/ULID) host-app user keys out of
+the box — no code or migration edits required:
+
+- Every user-id parameter is typed `int|string`, and incoming user ids are never
+  cast to `int` (so UUIDs aren't corrupted).
+- The user-referencing columns Escalated creates (`ticket_followers.user_id`,
+  `agent_profiles.user_id`, `tickets.assigned_to`/`requester_id`, the polymorphic
+  requester/author/causer columns, the role and skill pivots, etc.) are typed to
+  **match your user model's key type automatically**. At migration time Escalated
+  reflects the configured `user_model`: an auto-incrementing integer key yields
+  `unsignedBigInteger` columns; a `HasUuids`/`HasUlids`/string key yields
+  string-compatible columns.
+
+Override the detection with the `user_key_type` config (`'auto'` by default;
+`'bigint'`, `'uuid'`, `'ulid'`, or `'string'`):
+
+```php
+// config/escalated.php
+'user_key_type' => 'uuid',
+```
+
+> **Existing installs:** the column type is chosen when a migration runs. Apps
+> already migrated (e.g. as `bigint`) keep their columns; switching your user key
+> type after installing requires a manual migration.
 
 ## Frontend Integration
 

--- a/config/escalated.php
+++ b/config/escalated.php
@@ -37,6 +37,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User Key Type
+    |--------------------------------------------------------------------------
+    |
+    | Column type for the user-referencing foreign keys Escalated creates
+    | (ticket_followers.user_id, agent_profiles.user_id, tickets.assigned_to,
+    | etc.). Defaults to 'auto', which reflects your user model's key type so
+    | UUID/ULID/string-keyed user tables migrate cleanly with no edits. Set
+    | explicitly to 'bigint', 'uuid', 'ulid', or 'string' to override.
+    |
+    | Note: this affects columns at migration time. Apps that already migrated
+    | (e.g. as 'bigint') keep their existing columns; switching key types after
+    | install requires a manual migration.
+    |
+    */
+    'user_key_type' => env('ESCALATED_USER_KEY_TYPE', 'auto'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Hosted / Cloud Configuration
     |--------------------------------------------------------------------------
     */

--- a/database/migrations/2024_01_01_000001_create_escalated_departments_table.php
+++ b/database/migrations/2024_01_01_000001_create_escalated_departments_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -21,7 +22,7 @@ return new class extends Migration
 
         Schema::create($prefix.'department_agent', function (Blueprint $table) use ($prefix) {
             $table->foreignId('department_id')->constrained($prefix.'departments')->cascadeOnDelete();
-            $table->unsignedBigInteger('agent_id');
+            Escalated::userForeignColumn($table, 'agent_id');
             $table->primary(['department_id', 'agent_id']);
         });
     }

--- a/database/migrations/2024_01_01_000003_create_escalated_tickets_table.php
+++ b/database/migrations/2024_01_01_000003_create_escalated_tickets_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,8 +14,8 @@ return new class extends Migration
         Schema::create($prefix.'tickets', function (Blueprint $table) {
             $table->id();
             $table->string('reference')->unique();
-            $table->morphs('requester');
-            $table->unsignedBigInteger('assigned_to')->nullable()->index();
+            Escalated::userMorphs($table, 'requester');
+            Escalated::userForeignColumn($table, 'assigned_to')->nullable()->index();
             $table->string('subject');
             $table->text('description');
             $table->string('status')->default('open')->index();

--- a/database/migrations/2024_01_01_000004_create_escalated_replies_table.php
+++ b/database/migrations/2024_01_01_000004_create_escalated_replies_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::create($prefix.'replies', function (Blueprint $table) use ($prefix) {
             $table->id();
             $table->foreignId('ticket_id')->constrained($prefix.'tickets')->cascadeOnDelete();
-            $table->nullableMorphs('author');
+            Escalated::userMorphs($table, 'author', true);
             $table->text('body');
             $table->boolean('is_internal_note')->default(false);
             $table->string('type')->default('reply');

--- a/database/migrations/2024_01_01_000007_create_escalated_ticket_activities_table.php
+++ b/database/migrations/2024_01_01_000007_create_escalated_ticket_activities_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::create($prefix.'ticket_activities', function (Blueprint $table) use ($prefix) {
             $table->id();
             $table->foreignId('ticket_id')->constrained($prefix.'tickets')->cascadeOnDelete();
-            $table->nullableMorphs('causer');
+            Escalated::userMorphs($table, 'causer', true);
             $table->string('type');
             $table->json('properties')->nullable();
             $table->timestamps();

--- a/database/migrations/2024_01_01_000009_create_escalated_canned_responses_table.php
+++ b/database/migrations/2024_01_01_000009_create_escalated_canned_responses_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +16,7 @@ return new class extends Migration
             $table->string('title');
             $table->text('body');
             $table->string('category')->nullable();
-            $table->unsignedBigInteger('created_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
             $table->boolean('is_shared')->default(true);
             $table->timestamps();
         });

--- a/database/migrations/2024_01_01_000011_add_guest_fields_to_escalated_tickets_table.php
+++ b/database/migrations/2024_01_01_000011_add_guest_fields_to_escalated_tickets_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::table($prefix.'tickets', function (Blueprint $table) {
             // Make requester nullable for guest tickets
             $table->string('requester_type')->nullable()->change();
-            $table->unsignedBigInteger('requester_id')->nullable()->change();
+            Escalated::userForeignColumn($table, 'requester_id')->nullable()->change();
 
             // Guest ticket fields
             $table->string('guest_name')->nullable()->after('requester_id');
@@ -29,7 +30,7 @@ return new class extends Migration
         Schema::table($prefix.'tickets', function (Blueprint $table) {
             $table->dropColumn(['guest_name', 'guest_email', 'guest_token']);
             $table->string('requester_type')->nullable(false)->change();
-            $table->unsignedBigInteger('requester_id')->nullable(false)->change();
+            Escalated::userForeignColumn($table, 'requester_id')->nullable(false)->change();
         });
     }
 };

--- a/database/migrations/2024_01_01_000013_create_escalated_macros_table.php
+++ b/database/migrations/2024_01_01_000013_create_escalated_macros_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -20,7 +21,7 @@ return new class extends Migration
             // id from pre-Laravel-5.8 scaffolds, INT UNSIGNED from
             // `increments()`, UUID/CHAR(36) from `HasUuids`) — any of which
             // make MariaDB reject FK creation with errno 150. See #88.
-            $table->unsignedBigInteger('created_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
             $table->boolean('is_shared')->default(true);
             $table->integer('order')->default(0);
             $table->timestamps();

--- a/database/migrations/2024_01_01_000014_create_escalated_ticket_followers_table.php
+++ b/database/migrations/2024_01_01_000014_create_escalated_ticket_followers_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::create($prefix.'ticket_followers', function (Blueprint $table) use ($prefix) {
             $table->foreignId('ticket_id')->constrained($prefix.'tickets')->cascadeOnDelete();
             // No DB-level FK to host `users` — see #88 / macros migration for rationale.
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->timestamps();
             $table->unique(['ticket_id', 'user_id']);
         });

--- a/database/migrations/2024_01_01_000015_create_escalated_satisfaction_ratings_table.php
+++ b/database/migrations/2024_01_01_000015_create_escalated_satisfaction_ratings_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +16,7 @@ return new class extends Migration
             $table->foreignId('ticket_id')->unique()->constrained($prefix.'tickets')->cascadeOnDelete();
             $table->tinyInteger('rating');
             $table->text('comment')->nullable();
-            $table->nullableMorphs('rated_by');
+            Escalated::userMorphs($table, 'rated_by', true);
             $table->timestamp('created_at')->nullable();
         });
     }

--- a/database/migrations/2024_01_01_000017_create_escalated_api_tokens_table.php
+++ b/database/migrations/2024_01_01_000017_create_escalated_api_tokens_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
 
         Schema::create($prefix.'api_tokens', function (Blueprint $table) {
             $table->id();
-            $table->morphs('tokenable');
+            Escalated::userMorphs($table, 'tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->json('abilities')->nullable();

--- a/database/migrations/2026_02_24_000005_create_escalated_roles_tables.php
+++ b/database/migrations/2026_02_24_000005_create_escalated_roles_tables.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -34,7 +35,7 @@ return new class extends Migration
         });
 
         Schema::create($prefix.'role_user', function (Blueprint $table) use ($prefix) {
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->foreignId('role_id')->constrained($prefix.'roles')->cascadeOnDelete();
             $table->primary(['user_id', 'role_id']);
         });

--- a/database/migrations/2026_02_24_000006_create_escalated_audit_logs_table.php
+++ b/database/migrations/2026_02_24_000006_create_escalated_audit_logs_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
 
         Schema::create($prefix.'audit_logs', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('user_id')->nullable();
+            Escalated::userForeignColumn($table, 'user_id')->nullable();
             $table->string('action');
             $table->string('auditable_type');
             $table->unsignedBigInteger('auditable_id');

--- a/database/migrations/2026_02_24_000009_create_escalated_side_conversations_table.php
+++ b/database/migrations/2026_02_24_000009_create_escalated_side_conversations_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -16,7 +17,7 @@ return new class extends Migration
             $table->string('subject');
             $table->string('channel')->default('internal'); // internal, email
             $table->string('status')->default('open'); // open, closed
-            $table->unsignedBigInteger('created_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
             $table->timestamps();
 
             $table->foreign('ticket_id')
@@ -31,7 +32,7 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('side_conversation_id');
             $table->text('body');
-            $table->unsignedBigInteger('author_id')->nullable();
+            Escalated::userForeignColumn($table, 'author_id')->nullable();
             $table->timestamps();
 
             $table->foreign('side_conversation_id')

--- a/database/migrations/2026_02_24_000010_create_escalated_agent_profiles_table.php
+++ b/database/migrations/2026_02_24_000010_create_escalated_agent_profiles_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
 
         Schema::create($prefix.'agent_profiles', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('user_id')->unique();
+            Escalated::userForeignColumn($table, 'user_id')->unique();
             $table->string('agent_type')->default('full'); // full, light
             $table->unsignedInteger('max_tickets')->nullable();
             $table->timestamps();

--- a/database/migrations/2026_02_24_000011_create_escalated_skills_table.php
+++ b/database/migrations/2026_02_24_000011_create_escalated_skills_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -21,7 +22,7 @@ return new class extends Migration
 
         Schema::create($prefix.'agent_skill', function (Blueprint $table) use ($prefix) {
             $table->id();
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->unsignedBigInteger('skill_id');
             $table->unsignedInteger('proficiency')->default(1); // 1-5
 

--- a/database/migrations/2026_02_24_000012_create_escalated_agent_capacity_table.php
+++ b/database/migrations/2026_02_24_000012_create_escalated_agent_capacity_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
 
         Schema::create($prefix.'agent_capacity', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->string('channel')->default('default');
             $table->unsignedInteger('max_concurrent')->default(10);
             $table->unsignedInteger('current_count')->default(0);

--- a/database/migrations/2026_02_24_000016_create_escalated_knowledge_base_tables.php
+++ b/database/migrations/2026_02_24_000016_create_escalated_knowledge_base_tables.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -32,7 +33,7 @@ return new class extends Migration
             $table->string('slug')->unique();
             $table->longText('body')->nullable();
             $table->string('status')->default('draft');
-            $table->unsignedBigInteger('author_id')->nullable();
+            Escalated::userForeignColumn($table, 'author_id')->nullable();
             $table->unsignedInteger('view_count')->default(0);
             $table->unsignedInteger('helpful_count')->default(0);
             $table->unsignedInteger('not_helpful_count')->default(0);

--- a/database/migrations/2026_02_24_000018_add_two_factor_columns.php
+++ b/database/migrations/2026_02_24_000018_add_two_factor_columns.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
 
         Schema::create($prefix.'two_factor', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->text('secret');
             $table->text('recovery_codes')->nullable();
             $table->timestamp('confirmed_at')->nullable();

--- a/database/migrations/2026_03_16_000001_create_escalated_import_jobs_table.php
+++ b/database/migrations/2026_03_16_000001_create_escalated_import_jobs_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
 
         Schema::create($prefix.'import_jobs', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->string('platform', 50);
             $table->string('status', 30)->default('pending');
             $table->text('credentials')->nullable();

--- a/database/migrations/2026_04_07_000001_add_snooze_columns_to_escalated_tickets.php
+++ b/database/migrations/2026_04_07_000001_add_snooze_columns_to_escalated_tickets.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::table($prefix.'tickets', function (Blueprint $table) {
             $table->dateTime('snoozed_until')->nullable()->after('closed_at');
             // No DB-level FK to host `users` — see #88 / macros migration for rationale.
-            $table->unsignedBigInteger('snoozed_by')->nullable()->after('snoozed_until');
+            Escalated::userForeignColumn($table, 'snoozed_by')->nullable()->after('snoozed_until');
             $table->string('status_before_snooze')->nullable()->after('snoozed_by');
 
             $table->index('snoozed_until');

--- a/database/migrations/2026_04_07_000001_create_escalated_saved_views_table.php
+++ b/database/migrations/2026_04_07_000001_create_escalated_saved_views_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +16,7 @@ return new class extends Migration
             $table->string('name');
             $table->json('filters');
             // No DB-level FK to host `users` — see #88 / macros migration for rationale.
-            $table->unsignedBigInteger('user_id')->nullable();
+            Escalated::userForeignColumn($table, 'user_id')->nullable();
             $table->boolean('is_shared')->default(false);
             $table->boolean('is_default')->default(false);
             $table->integer('position')->default(0);

--- a/database/migrations/2026_04_07_000003_create_escalated_chat_sessions_table.php
+++ b/database/migrations/2026_04_07_000003_create_escalated_chat_sessions_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('ticket_id');
             $table->string('customer_session_id', 64)->unique();
-            $table->unsignedBigInteger('agent_id')->nullable()->index();
+            Escalated::userForeignColumn($table, 'agent_id')->nullable()->index();
             $table->string('status')->default('waiting')->index();
             $table->timestamp('started_at');
             $table->timestamp('ended_at')->nullable();

--- a/database/migrations/2026_04_07_100001_create_escalated_mentions_table.php
+++ b/database/migrations/2026_04_07_100001_create_escalated_mentions_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('reply_id')->constrained($prefix.'replies')->cascadeOnDelete();
             // No DB-level FK to host `users` — see #88 / macros migration for rationale.
-            $table->unsignedBigInteger('user_id');
+            Escalated::userForeignColumn($table, 'user_id');
             $table->datetime('read_at')->nullable();
             $table->timestamps();
 

--- a/database/migrations/2026_04_07_100001_create_escalated_workflows_table.php
+++ b/database/migrations/2026_04_07_100001_create_escalated_workflows_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->integer('position')->default(0);
             $table->timestamp('last_triggered_at')->nullable();
             $table->integer('trigger_count')->default(0);
-            $table->unsignedBigInteger('created_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
             $table->timestamps();
 
             $table->index('trigger_event');

--- a/database/migrations/2026_04_24_000001_create_escalated_contacts_table.php
+++ b/database/migrations/2026_04_24_000001_create_escalated_contacts_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -24,7 +25,7 @@ return new class extends Migration
             $table->id();
             $table->string('email', 320);
             $table->string('name')->nullable();
-            $table->unsignedBigInteger('user_id')->nullable()
+            Escalated::userForeignColumn($table, 'user_id')->nullable()
                 ->comment('Linked host-app user id once the contact creates an account');
             $table->json('metadata')->nullable();
             $table->timestamps();

--- a/src/Escalated.php
+++ b/src/Escalated.php
@@ -3,6 +3,8 @@
 namespace Escalated\Laravel;
 
 use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Support\Facades\Schema;
 
 class Escalated
@@ -49,6 +51,70 @@ class Escalated
         $model = static::userModel();
 
         return new $model;
+    }
+
+    /**
+     * Resolve the column type to use for host-user foreign-key columns.
+     *
+     * Returns one of 'bigint' | 'uuid' | 'ulid' | 'string'. The
+     * `escalated.user_key_type` config defaults to 'auto', which reflects
+     * the configured user model's key type so the package's user-referencing
+     * columns match the host's user primary key — UUID/ULID/string-keyed
+     * apps then migrate cleanly with no manual edits.
+     */
+    public static function userKeyType(): string
+    {
+        $configured = config('escalated.user_key_type', 'auto');
+
+        if ($configured !== 'auto') {
+            return $configured;
+        }
+
+        $instance = static::newUserModel();
+
+        // Non-incrementing or non-integer keys (HasUuids/HasUlids/custom string)
+        // get a string-compatible column; classic auto-increment ids stay bigint.
+        if ($instance->getKeyType() !== 'int' || ! $instance->getIncrementing()) {
+            return 'string';
+        }
+
+        return 'bigint';
+    }
+
+    /**
+     * Add a host-user foreign-key column to a migration blueprint, typed to
+     * match the host's user primary key (see {@see userKeyType()}). Returns the
+     * column definition so callers can chain ->nullable()/->index()/etc.
+     */
+    public static function userForeignColumn(Blueprint $table, string $column): ColumnDefinition
+    {
+        return match (static::userKeyType()) {
+            'uuid' => $table->uuid($column),
+            'ulid' => $table->ulid($column),
+            'string' => $table->string($column),
+            default => $table->unsignedBigInteger($column),
+        };
+    }
+
+    /**
+     * Add a polymorphic relationship whose related model may be the host user
+     * (e.g. ticket requester, reply author, activity causer). The `_id` column
+     * is typed to match the host user key (see {@see userForeignColumn()}) so a
+     * UUID/string user id can be stored alongside Escalated's own integer ids.
+     * Mirrors Blueprint::morphs()/nullableMorphs() (type column + id column +
+     * composite index).
+     */
+    public static function userMorphs(Blueprint $table, string $name, bool $nullable = false): void
+    {
+        $typeColumn = $table->string("{$name}_type");
+        $idColumn = static::userForeignColumn($table, "{$name}_id");
+
+        if ($nullable) {
+            $typeColumn->nullable();
+            $idColumn->nullable();
+        }
+
+        $table->index(["{$name}_type", "{$name}_id"]);
     }
 
     /**

--- a/src/Escalated.php
+++ b/src/Escalated.php
@@ -3,6 +3,8 @@
 namespace Escalated\Laravel;
 
 use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Support\Facades\Schema;
@@ -72,13 +74,24 @@ class Escalated
 
         $instance = static::newUserModel();
 
-        // Non-incrementing or non-integer keys (HasUuids/HasUlids/custom string)
-        // get a string-compatible column; classic auto-increment ids stay bigint.
-        if ($instance->getKeyType() !== 'int' || ! $instance->getIncrementing()) {
-            return 'string';
+        // Classic auto-incrementing integer key → bigint (unchanged behavior).
+        if ($instance->getKeyType() === 'int' && $instance->getIncrementing()) {
+            return 'bigint';
         }
 
-        return 'bigint';
+        // Non-incrementing / string keys: prefer a native uuid/ulid column when
+        // the model uses the matching trait, otherwise a generic string column.
+        $traits = class_uses_recursive($instance);
+
+        if (in_array(HasUlids::class, $traits, true)) {
+            return 'ulid';
+        }
+
+        if (in_array(HasUuids::class, $traits, true)) {
+            return 'uuid';
+        }
+
+        return 'string';
     }
 
     /**

--- a/src/Http/Controllers/Api/TicketController.php
+++ b/src/Http/Controllers/Api/TicketController.php
@@ -136,8 +136,12 @@ class TicketController extends Controller
 
     public function assign(Ticket $ticket, Request $request): JsonResponse
     {
+        $userModel = Escalated::newUserModel();
+
         $validated = $request->validate([
-            'agent_id' => 'required|integer|exists:users,id',
+            // Accept both integer and string/UUID host-app user keys, validated
+            // against the host's actual user table + key column.
+            'agent_id' => ['required', Rule::exists($userModel->getTable(), $userModel->getKeyName())],
         ]);
 
         $this->assignmentService->assign($ticket, $validated['agent_id'], $request->user());

--- a/src/Http/Requests/AssignTicketRequest.php
+++ b/src/Http/Requests/AssignTicketRequest.php
@@ -14,7 +14,8 @@ class AssignTicketRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'agent_id' => ['required', 'integer'],
+            // Accept both integer and string/UUID host-app user keys.
+            'agent_id' => ['required'],
         ];
     }
 }

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -460,12 +460,12 @@ class Ticket extends Model
         return $this->fresh();
     }
 
-    public function assign(Model|int $user, ?Ticketable $causer = null): self
+    public function assign(Model|int|string $user, ?Ticketable $causer = null): self
     {
         $userModel = Escalated::userModel();
 
-        // If an ID is provided, attempt to find the user
-        if (is_int($user)) {
+        // If a scalar id (int or string/UUID) is provided, attempt to find the user.
+        if (! $user instanceof Model) {
             $userId = $user;
             $user = $userModel::find($userId);
 
@@ -479,9 +479,9 @@ class Ticket extends Model
             throw new \InvalidArgumentException("Assigned user must be an instance of {$userModel}");
         }
 
-        $this->update(['assigned_to' => $user->id]);
+        $this->update(['assigned_to' => $user->getKey()]);
 
-        $this->logActivity(ActivityType::Assigned, $causer, ['agent_id' => $user->id]);
+        $this->logActivity(ActivityType::Assigned, $causer, ['agent_id' => $user->getKey()]);
 
         Events\TicketAssigned::dispatch($this, $user->id, $causer);
 

--- a/src/Services/AutomationRunner.php
+++ b/src/Services/AutomationRunner.php
@@ -108,7 +108,7 @@ class AutomationRunner
                         break;
 
                     case 'assign':
-                        $ticket->update(['assigned_to' => (int) $value]);
+                        $ticket->update(['assigned_to' => $value]);
                         break;
 
                     case 'add_tag':

--- a/src/Services/EscalationService.php
+++ b/src/Services/EscalationService.php
@@ -64,7 +64,7 @@ class EscalationService
                 'change_priority' => $this->ticketService->changePriority(
                     $ticket, TicketPriority::from($action['value'])
                 ),
-                'assign_to' => $this->assignmentService->assign($ticket, (int) $action['value']),
+                'assign_to' => $this->assignmentService->assign($ticket, $action['value']),
                 'change_department' => $this->ticketService->changeDepartment($ticket, (int) $action['value']),
                 default => null,
             };

--- a/src/Services/WorkflowEngine.php
+++ b/src/Services/WorkflowEngine.php
@@ -331,7 +331,7 @@ class WorkflowEngine
                 $ticket->update(['assigned_to' => $agentId]);
             }
         } else {
-            $ticket->update(['assigned_to' => (int) $value]);
+            $ticket->update(['assigned_to' => $value]);
         }
     }
 
@@ -533,7 +533,7 @@ class WorkflowEngine
             match ($type) {
                 'status' => $ticket->update(['status' => TicketStatus::tryFrom($actionValue) ?? $ticket->status]),
                 'priority' => $ticket->update(['priority' => TicketPriority::tryFrom($actionValue) ?? $ticket->priority]),
-                'assign' => $ticket->update(['assigned_to' => (int) $actionValue]),
+                'assign' => $ticket->update(['assigned_to' => $actionValue]),
                 'tags' => $ticket->tags()->syncWithoutDetaching(
                     Tag::whereIn('name', (array) $actionValue)->pluck('id')->toArray()
                 ),

--- a/tests/Feature/UserKeyTypeTest.php
+++ b/tests/Feature/UserKeyTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Escalated\Laravel\Escalated;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Verifies that the package types its host-user foreign keys to match the
+// configured user model key type (auto-detected), so UUID/string-keyed apps
+// migrate cleanly. Column types are probed through the real schema builder.
+
+afterEach(fn () => Schema::dropIfExists('escalated_ukt_probe'));
+
+function probeUserColumnType(string $keyType): string
+{
+    config()->set('escalated.user_key_type', $keyType);
+    Schema::dropIfExists('escalated_ukt_probe');
+    Schema::create('escalated_ukt_probe', function (Blueprint $table) {
+        $table->id();
+        Escalated::userForeignColumn($table, 'user_id');
+    });
+
+    return Schema::getColumnType('escalated_ukt_probe', 'user_id');
+}
+
+it('auto-resolves to bigint for the default integer-keyed user model', function () {
+    config()->set('escalated.user_key_type', 'auto');
+
+    expect(Escalated::userKeyType())->toBe('bigint');
+});
+
+it('honors an explicit user_key_type override', function () {
+    config()->set('escalated.user_key_type', 'uuid');
+    expect(Escalated::userKeyType())->toBe('uuid');
+
+    config()->set('escalated.user_key_type', 'string');
+    expect(Escalated::userKeyType())->toBe('string');
+});
+
+it('creates an integer column for bigint keys', function () {
+    expect(probeUserColumnType('bigint'))->toBe('integer');
+});
+
+it('creates a string-compatible column for uuid and string keys', function () {
+    expect(probeUserColumnType('uuid'))->not->toBe('integer')
+        ->and(probeUserColumnType('string'))->not->toBe('integer');
+});
+
+it('builds user morph columns sized to the key type', function () {
+    config()->set('escalated.user_key_type', 'uuid');
+    Schema::dropIfExists('escalated_ukt_probe');
+    Schema::create('escalated_ukt_probe', function (Blueprint $table) {
+        $table->id();
+        Escalated::userMorphs($table, 'requester');
+    });
+
+    expect(Schema::hasColumn('escalated_ukt_probe', 'requester_type'))->toBeTrue()
+        ->and(Schema::hasColumn('escalated_ukt_probe', 'requester_id'))->toBeTrue()
+        ->and(Schema::getColumnType('escalated_ukt_probe', 'requester_id'))->not->toBe('integer');
+});

--- a/tests/Feature/UuidUserIdTest.php
+++ b/tests/Feature/UuidUserIdTest.php
@@ -8,6 +8,24 @@ use Escalated\Laravel\Models\Ticket;
 // Regression coverage for host apps whose User model uses a UUID/string primary
 // key. The package must accept string user ids throughout without a TypeError.
 
+it('assigns a ticket via a string user id without a type error', function () {
+    $agent = $this->createAgent();
+    $ticket = Ticket::factory()->create();
+
+    // Passing the id as a string (as a UUID host would) must route through the
+    // find path and assign, not throw a TypeError on Ticket::assign().
+    $ticket->assign((string) $agent->getKey());
+
+    expect($ticket->fresh()->assigned_to)->toEqual($agent->getKey());
+});
+
+it('rejects an unknown string user id with a clean exception, not a TypeError', function () {
+    $ticket = Ticket::factory()->create();
+
+    expect(fn () => $ticket->assign('9f1c2d3e-0000-0000-0000-000000000000'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
 it('scopes saved views for a string/uuid user id without a type error', function () {
     $uuid = '9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f';
     $otherUuid = '00000000-0000-0000-0000-000000000000';


### PR DESCRIPTION
Builds on #110. Refs #109.

> **Stacked on #110** (`fix/uuid-string-user-ids`). Review/merge #110 first; GitHub will retarget this to `main` once #110 lands. The diff shown here is just the auto-detection delta.

## What
#110 made the *code* accept `int|string` user ids. This makes the *schema* match automatically, so a UUID/ULID/string-keyed host app installs with **zero manual migration edits**.

- `Escalated::userKeyType()` — reflects the configured `user_model` at migration time (`auto`), or honors the new `escalated.user_key_type` config (`bigint`/`uuid`/`ulid`/`string`). Integer auto-increment key → `bigint`; `HasUuids`/`HasUlids`/string key → string-compatible.
- `Escalated::userForeignColumn()` / `Escalated::userMorphs()` — create columns of the resolved type.
- Applied across **all** user-referencing migration columns (`ticket_followers.user_id`, `agent_profiles.user_id`, `tickets.assigned_to`, role/skill pivots, `audit_logs`, `mentions`, `saved_views`, `contacts`, `chat_sessions.agent_id`, etc.) **and** the user-related polymorphic columns (`requester`, `author`, `causer`, `rated_by`, `tokenable`). Internal morphs (`attachable`, `entity`) and internal FKs stay `bigint`.

## Backward compatibility
Integer-keyed apps are unaffected: `auto` resolves to `unsignedBigInteger`, producing the identical schema. The full suite (**654 tests**) still passes on the integer path.

## Testing
- New `tests/Feature/UserKeyTypeTest.php` probes column types through the real schema builder: `bigint` → integer column, `uuid`/`string` → string-compatible column; plus the `userMorphs` columns. 5 pass.
- `php -l` + Pint clean on changed files.

## Caveat
Column type is chosen when a migration runs, so existing installs keep their columns; switching key type post-install needs a manual migration (documented in the README note).