### PR TITLE
fix(deps): bump qs 6.15.1 -> 6.15.2 (CVE-2026-8723)

### DIFF
--- a/docker/host-app/package-lock.json
+++ b/docker/host-app/package-lock.json
@@ -1735,9 +1735,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"


### PR DESCRIPTION
Bumps the transitive `qs` dependency (pulled in via `@inertiajs/core` in the demo host-app under `docker/host-app/`) from **6.15.1** to **6.15.2** to remediate **CVE-2026-8723** (NULL pointer dereference, medium 6.3).

- Patch release; `qs@6.15.2` has identical dependencies (`side-channel ^6.15.1` → unchanged `side-channel ^1.1.0`), so this is a surgical lockfile-only bump (version + resolved URL + integrity).
- Satisfies the existing `@inertiajs/core` requirement `qs: ^6.15.0`.
- No `package.json` change needed; the range already permits 6.15.2.