### PR TITLE
fix: v1.4.0 upgrade-safety regressions (skills migration, assign validation, AssignmentService ctor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-29
+
+### Fixed
+- Upgrade safety: add a dedicated migration (`add_routing_columns_to_escalated_skills_table`) that backfills the `routing_tag_ids`/`routing_department_ids` columns. v1.4.0 added them by editing the original `create_escalated_skills_table` migration, which never re-runs on an existing install — so apps upgraded from an earlier version were missing the columns and **every skill create/edit failed** (`Skill::saving()` always writes them). The new migration is guarded by `Schema::hasColumn`, so it is a no-op on fresh installs.
+- `AssignTicketRequest` (Admin/Agent assign endpoints) again validates that `agent_id` exists (against the host user key), so an unknown/garbage id returns a clean `422` instead of a `500`. The `integer` rule remains dropped so UUID/string keys are accepted (matching `Api\TicketController`).
+- `AssignmentService::__construct()` `$skillRoutingService` is now optional (resolved from the container when omitted), restoring the v1.3.0 `new AssignmentService($manager)` single-argument signature for direct instantiation / subclasses.
+
+### Notes (upgrading from < 1.4.0)
+- **`int` → `int|string` widening (UUID/string user-key support).** The `TicketDriver` contract's `assignTicket()` and several public `Ticket` methods (`assign`, `follow`, `unfollow`, `isFollowedBy`, `scopeAssignedTo`) now accept `int|string`. If your app **implements `TicketDriver`** or **subclasses `Ticket`** and type-hinted these parameters as `int`, widen them to `int|string` to avoid a PHP "must be compatible" fatal. Apps that only *call* these methods are unaffected.
+- The `TicketAssigned` event's `$agentId` is now `int|string`; for UUID/string-keyed apps the broadcast `agent_id` is a string. Integer-keyed apps are unchanged.
+
 ## [1.4.0] - 2026-05-29
 
 ### Added

--- a/database/migrations/2026_05_29_000001_add_routing_columns_to_escalated_skills_table.php
+++ b/database/migrations/2026_05_29_000001_add_routing_columns_to_escalated_skills_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Escalated\Laravel\Escalated;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Backfills the skills routing columns for installs created before they were
+ * added. The columns were introduced by editing the original
+ * `create_escalated_skills_table` migration, which never re-runs on an existing
+ * install — so apps that migrated an earlier version are missing them, and
+ * `Skill::saving()` (which always writes them) would fail. This guarded ALTER
+ * adds them only where absent, so it is a no-op on fresh installs.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $table = Escalated::table('skills');
+
+        if (! Schema::hasColumn($table, 'routing_tag_ids')) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->json('routing_tag_ids')->nullable()->after('slug');
+            });
+        }
+
+        if (! Schema::hasColumn($table, 'routing_department_ids')) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->json('routing_department_ids')->nullable()->after('routing_tag_ids');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $table = Escalated::table('skills');
+
+        $columns = array_values(array_filter(
+            ['routing_tag_ids', 'routing_department_ids'],
+            fn (string $column) => Schema::hasColumn($table, $column),
+        ));
+
+        if ($columns !== []) {
+            Schema::table($table, function (Blueprint $blueprint) use ($columns) {
+                $blueprint->dropColumn($columns);
+            });
+        }
+    }
+};

--- a/src/Http/Requests/AssignTicketRequest.php
+++ b/src/Http/Requests/AssignTicketRequest.php
@@ -2,7 +2,9 @@
 
 namespace Escalated\Laravel\Http\Requests;
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AssignTicketRequest extends FormRequest
 {
@@ -13,9 +15,13 @@ class AssignTicketRequest extends FormRequest
 
     public function rules(): array
     {
+        // Accept both integer and string/UUID host-app user keys, but still
+        // validate the agent exists so bad input fails with a clean 422 rather
+        // than a 500 from the assignment path (mirrors Api\TicketController).
+        $userModel = Escalated::newUserModel();
+
         return [
-            // Accept both integer and string/UUID host-app user keys.
-            'agent_id' => ['required'],
+            'agent_id' => ['required', Rule::exists($userModel->getTable(), $userModel->getKeyName())],
         ];
     }
 }

--- a/src/Services/AssignmentService.php
+++ b/src/Services/AssignmentService.php
@@ -11,7 +11,7 @@ class AssignmentService
 {
     public function __construct(
         protected EscalatedManager $manager,
-        protected SkillRoutingService $skillRoutingService,
+        protected ?SkillRoutingService $skillRoutingService = null,
     ) {}
 
     public function assign(Ticket $ticket, int|string $agentId, ?Ticketable $causer = null): Ticket
@@ -31,7 +31,8 @@ class AssignmentService
 
     public function autoAssign(Ticket $ticket): ?Ticket
     {
-        $matchedAgent = $this->skillRoutingService->findMatchingAgents($ticket)->first();
+        $skillRouting = $this->skillRoutingService ??= app(SkillRoutingService::class);
+        $matchedAgent = $skillRouting->findMatchingAgents($ticket)->first();
         if ($matchedAgent) {
             return $this->assign($ticket, $matchedAgent->getKey());
         }


### PR DESCRIPTION
Fixes upgrade-safety regressions found in a breaking-change audit of the `v1.3.0..v1.4.0` diff. All three are backed by the full Pest suite (**661 passed**) + Pint.

## 🔴 Critical — skill management broke on upgraded installs

v1.4.0's skills-routing feature (#95) added `routing_tag_ids` / `routing_department_ids` by **editing the original `create_escalated_skills_table` migration** (dated 2026-02-24, long since run on every install). Laravel never re-runs a recorded migration, so apps upgraded from an earlier version never got the columns — and `Skill::saving()` writes them on every save, so **creating/editing any skill 500s with "column not found."** Fresh installs were fine, which is why CI/tests didn't catch it.

- Adds `2026_05_29_000001_add_routing_columns_to_escalated_skills_table` — a `Schema::hasColumn`-guarded ALTER that backfills the columns on existing installs and is a **no-op on fresh installs**.

## 🟠 Medium

- **`AssignTicketRequest`** dropped its `integer` rule entirely in v1.4.0, so a bad/unknown `agent_id` on the Admin & Agent web assign endpoints 500s (via `User::find()` → `InvalidArgumentException`) instead of returning a clean `422`. Restores existence validation against the host user key (`Rule::exists`), mirroring `Api\TicketController`. Keeps `int|string` acceptance (no `integer` rule).
- **`AssignmentService::__construct`** became 2-required-args in v1.4.0 (added `SkillRoutingService`), breaking `new AssignmentService($manager)` and `parent::__construct($manager)` with `ArgumentCountError`. Made the param optional with a container fallback — restores the v1.3.0 single-arg signature. Container resolution is unchanged.

## 🟡 Documented (inherent to UUID support — CHANGELOG upgrade notes)

The `int → int|string` widening on the public `TicketDriver` contract and `Ticket` methods is an **LSP fatal** for host apps that *implement `TicketDriver`* or *subclass `Ticket`* with `int`-typed params (overriding params must be contravariant). This is unavoidable for UUID/string user-key support, so it's documented as an upgrade note rather than changed. The `TicketAssigned` event's `agentId` is likewise now `int|string` (string for UUID hosts). Integer-keyed apps that only *call* these are unaffected.

---

Intended for a **v1.4.1** patch release.
