### PR TITLE
feat(tickets): attachable ticket subjects + presentation contract (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Ticket subjects: attach host-app entities (Project, Customer, asset, …) that a ticket is *about*, distinct from the requester. Models implement the new `Escalated\Laravel\Contracts\TicketSubject` contract (or use the `PresentsAsTicketSubject` trait) to expose a title/subtitle/url/color/icon for the ticket UI. A ticket can reference several subjects via `attachSubject()`/`detachSubject()`/`syncSubjects()`; they're serialized on `TicketResource` as a `subjects[]` array. Agent attach/detach endpoints resolve types strictly against the new `escalated.ticket_subjects.types` allowlist. `subject_id` is stored as a string so integer/UUID/string-keyed host models all work. (#89)
+
 ## [1.4.1] - 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,6 +121,77 @@ Override the detection with the `user_key_type` config (`'auto'` by default;
 > already migrated (e.g. as `bigint`) keep their columns; switching your user key
 > type after installing requires a manual migration.
 
+## Ticket subjects
+
+A ticket has a **requester** (the person who raised it) and a **subject line**
+(free text). Sometimes a ticket is also *about* one or more host-app entities —
+a Project, a Customer, an asset — that aren't people. Attach them as ticket
+**subjects** so agents see what the ticket concerns and can jump straight to it
+in your app.
+
+Make any model attachable by implementing the `TicketSubject` contract. The
+`PresentsAsTicketSubject` trait gives sane defaults — override only what you need:
+
+```php
+use Escalated\Laravel\Concerns\PresentsAsTicketSubject;
+use Escalated\Laravel\Contracts\TicketSubject;
+
+class Project extends Model implements TicketSubject
+{
+    use PresentsAsTicketSubject;
+
+    public function ticketSubjectSubtitle(): ?string
+    {
+        return 'Project · '.$this->customer->name;
+    }
+
+    public function ticketSubjectUrl(): ?string
+    {
+        return route('projects.show', $this);
+    }
+
+    public function ticketSubjectColor(): ?string
+    {
+        return '#2563eb';
+    }
+
+    public function ticketSubjectIcon(): ?string
+    {
+        return 'folder';
+    }
+}
+```
+
+Attach, detach, or sync subjects on a ticket — a ticket can reference several:
+
+```php
+$ticket->attachSubject($project, role: 'project');
+$ticket->attachSubject($customer, role: 'account');
+$ticket->syncSubjects([$project, [$customer, 'account']]);
+$ticket->detachSubject($project);
+```
+
+Each attached subject is serialized onto the ticket as
+`{ type, id, role, title, subtitle, url, color, icon }` for the frontend to
+render (clickable when `url` is set). `subject_id` is stored as a string, so
+integer, UUID, or string-keyed host models all work.
+
+To allow attaching subjects via the agent API (and protect against arbitrary
+class resolution from request input), list the permitted models in config:
+
+```php
+// config/escalated.php
+'ticket_subjects' => [
+    'types' => [
+        \App\Models\Project::class,
+        \App\Models\Customer::class,
+    ],
+],
+```
+
+Programmatic `attachSubject()` works for any model when the allowlist is empty;
+the agent API only accepts allowlisted types.
+
 ## Frontend Integration
 
 Escalated ships a Vue component library and default pages via the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.

--- a/config/escalated.php
+++ b/config/escalated.php
@@ -341,4 +341,27 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Ticket subjects
+    |--------------------------------------------------------------------------
+    |
+    | Host-app models a ticket can be *about* (a Project, Customer, asset, …),
+    | distinct from the requester. Attached models should implement
+    | Escalated\Laravel\Contracts\TicketSubject (or use the
+    | PresentsAsTicketSubject trait) so they render in the ticket UI.
+    |
+    | `types` is the allowlist of morph types (class names or morph-map
+    | aliases) the agent API is permitted to attach — this prevents arbitrary
+    | class resolution from request input. Leave empty to disable attaching via
+    | the API; programmatic $ticket->attachSubject($model) still works.
+    |
+    */
+    'ticket_subjects' => [
+        'types' => [
+            // \App\Models\Project::class,
+            // 'project' => \App\Models\Project::class,
+        ],
+    ],
+
 ];

--- a/database/migrations/2026_05_29_000002_create_escalated_ticket_subjects_table.php
+++ b/database/migrations/2026_05_29_000002_create_escalated_ticket_subjects_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Ticket subjects — the host-app entities a ticket is *about* (a Project,
+ * Customer, Lead, asset, …), distinct from the requester (the person who
+ * raised it) and the subject *line* (free text). A ticket can reference
+ * several heterogeneous host models; each is presented in the UI via the
+ * `Escalated\Laravel\Contracts\TicketSubject` contract.
+ *
+ * `subject_id` is a string so it can hold any host primary key type
+ * (integer, UUID, ULID, or other string) — subjects are arbitrary host
+ * models, not necessarily the configured user model.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $prefix = config('escalated.table_prefix', 'escalated_');
+
+        Schema::create($prefix.'ticket_subjects', function (Blueprint $table) use ($prefix) {
+            $table->id();
+            $table->unsignedBigInteger('ticket_id');
+            $table->string('subject_type');
+            $table->string('subject_id');
+            $table->string('role')->nullable()->comment('Optional label for this attachment, e.g. "project" or "account"');
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->foreign('ticket_id')
+                ->references('id')
+                ->on($prefix.'tickets')
+                ->cascadeOnDelete();
+
+            $table->unique(['ticket_id', 'subject_type', 'subject_id'], 'escalated_ticket_subject_unique');
+            $table->index(['subject_type', 'subject_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        $prefix = config('escalated.table_prefix', 'escalated_');
+
+        Schema::dropIfExists($prefix.'ticket_subjects');
+    }
+};

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -34,6 +34,7 @@ use Escalated\Laravel\Http\Controllers\Admin\TagController;
 use Escalated\Laravel\Http\Controllers\Admin\TicketController;
 use Escalated\Laravel\Http\Controllers\Admin\TicketLinkController;
 use Escalated\Laravel\Http\Controllers\Admin\TicketMergeController;
+use Escalated\Laravel\Http\Controllers\Admin\TicketSubjectController;
 use Escalated\Laravel\Http\Controllers\Admin\TwoFactorController;
 use Escalated\Laravel\Http\Controllers\Admin\UserController;
 use Escalated\Laravel\Http\Controllers\Admin\WebhookController;
@@ -63,6 +64,8 @@ Route::middleware(array_merge(config('escalated.routes.admin_middleware', ['web'
             Route::post('/tickets/{ticket}/status', [TicketController::class, 'status'])->name('escalated.admin.tickets.status');
             Route::post('/tickets/{ticket}/priority', [TicketController::class, 'priority'])->name('escalated.admin.tickets.priority');
             Route::post('/tickets/{ticket}/tags', [TicketController::class, 'tags'])->name('escalated.admin.tickets.tags');
+            Route::post('/tickets/{ticket}/subjects', [TicketSubjectController::class, 'store'])->name('escalated.admin.tickets.subjects.store');
+            Route::delete('/tickets/{ticket}/subjects/{subject}', [TicketSubjectController::class, 'destroy'])->name('escalated.admin.tickets.subjects.destroy');
             Route::post('/tickets/{ticket}/department', [TicketController::class, 'department'])->name('escalated.admin.tickets.department');
             Route::post('/tickets/{ticket}/macro', [TicketController::class, 'applyMacro'])->name('escalated.admin.tickets.macro');
             Route::post('/tickets/{ticket}/follow', [TicketController::class, 'follow'])->name('escalated.admin.tickets.follow');

--- a/src/Concerns/PresentsAsTicketSubject.php
+++ b/src/Concerns/PresentsAsTicketSubject.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Escalated\Laravel\Concerns;
+
+use Escalated\Laravel\Contracts\TicketSubject;
+
+/**
+ * Default implementation of {@see TicketSubject}.
+ *
+ * Drop this trait onto a host model and it becomes attachable to tickets with
+ * a reasonable presentation out of the box: the title falls back to a `name`
+ * or `title` attribute, everything else is null (no subtitle/url/color/icon).
+ * Override any method to customize.
+ *
+ *     class Project extends Model implements TicketSubject
+ *     {
+ *         use PresentsAsTicketSubject;
+ *
+ *         public function ticketSubjectSubtitle(): ?string
+ *         {
+ *             return 'Project · '.$this->customer->name;
+ *         }
+ *     }
+ */
+trait PresentsAsTicketSubject
+{
+    public function ticketSubjectTitle(): string
+    {
+        foreach (['name', 'title', 'label'] as $attribute) {
+            $value = $this->getAttribute($attribute);
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return class_basename($this).' #'.$this->getKey();
+    }
+
+    public function ticketSubjectSubtitle(): ?string
+    {
+        return null;
+    }
+
+    public function ticketSubjectUrl(): ?string
+    {
+        return null;
+    }
+
+    public function ticketSubjectColor(): ?string
+    {
+        return null;
+    }
+
+    public function ticketSubjectIcon(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Contracts/TicketSubject.php
+++ b/src/Contracts/TicketSubject.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Escalated\Laravel\Contracts;
+
+use Escalated\Laravel\Concerns\PresentsAsTicketSubject;
+
+/**
+ * A host-app model that can be attached to a ticket as its *subject* — the
+ * thing the ticket is about (a Project, Customer, Lead, asset, …), as opposed
+ * to the requester (the person who raised it).
+ *
+ * Implement this on any Eloquent model you want to attach to tickets. The
+ * methods drive how the subject is presented in the ticket UI. Use the
+ * {@see PresentsAsTicketSubject} trait for sane
+ * defaults and override only what you need.
+ */
+interface TicketSubject
+{
+    /** Primary label shown for the subject (e.g. "Acme Website Redesign"). */
+    public function ticketSubjectTitle(): string;
+
+    /** Secondary line (e.g. "Project · Acme Corp"). Null to omit. */
+    public function ticketSubjectSubtitle(): ?string;
+
+    /** Deep link into the host app for this subject. Null for non-clickable. */
+    public function ticketSubjectUrl(): ?string;
+
+    /** Accent color as a hex string or design token (e.g. "#2563eb"). Null for default. */
+    public function ticketSubjectColor(): ?string;
+
+    /** Icon slug the frontend maps to an icon (e.g. "folder", "building"). Null for default. */
+    public function ticketSubjectIcon(): ?string;
+}

--- a/src/Http/Controllers/Admin/TicketSubjectController.php
+++ b/src/Http/Controllers/Admin/TicketSubjectController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Escalated\Laravel\Http\Controllers\Admin;
+
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Models\TicketSubjectLink;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Attach/detach host-app subject models on a ticket. Types are resolved
+ * strictly against the `escalated.ticket_subjects.types` allowlist so request
+ * input can never instantiate an arbitrary class.
+ */
+class TicketSubjectController extends Controller
+{
+    public function store(Ticket $ticket, Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'type' => ['required', 'string'],
+            'id' => ['required'],
+            'role' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $class = $this->resolveAllowedModelClass($validated['type']);
+
+        $subject = $class::query()->find($validated['id']);
+
+        if ($subject === null) {
+            throw ValidationException::withMessages([
+                'id' => 'No matching subject was found.',
+            ]);
+        }
+
+        $ticket->attachSubject($subject, $validated['role'] ?? null);
+
+        return back();
+    }
+
+    public function destroy(Ticket $ticket, TicketSubjectLink $subject): RedirectResponse
+    {
+        abort_unless((int) $subject->ticket_id === (int) $ticket->getKey(), 404);
+
+        $subject->delete();
+
+        return back();
+    }
+
+    /**
+     * Resolve a request-supplied morph type to a model class, but only if it's
+     * in the configured allowlist. Throws a 422 otherwise.
+     */
+    protected function resolveAllowedModelClass(string $type): string
+    {
+        $allowed = collect((array) config('escalated.ticket_subjects.types', []))
+            ->flatMap(fn ($value, $key) => is_string($key) ? [$key, $value] : [$value])
+            ->all();
+
+        if (! in_array($type, $allowed, true)) {
+            throw ValidationException::withMessages([
+                'type' => "Subject type [{$type}] is not an allowed ticket subject.",
+            ]);
+        }
+
+        $class = Relation::getMorphedModel($type) ?? $type;
+
+        if (! is_string($class) || ! class_exists($class) || ! is_subclass_of($class, Model::class)) {
+            throw ValidationException::withMessages([
+                'type' => "Subject type [{$type}] could not be resolved to a model.",
+            ]);
+        }
+
+        return $class;
+    }
+}

--- a/src/Http/Resources/TicketResource.php
+++ b/src/Http/Resources/TicketResource.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Http\Resources;
 
+use Escalated\Laravel\Contracts\TicketSubject;
 use Escalated\Laravel\Services\TicketActionRegistry;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -40,6 +41,24 @@ class TicketResource extends JsonResource
                 'name' => $tag->name,
                 'color' => $tag->color,
             ])),
+            'subjects' => $this->whenLoaded('subjects', fn () => $this->subjects->map(function ($link) {
+                $subject = $link->subject;
+                $presents = $subject instanceof TicketSubject;
+
+                return [
+                    'type' => $link->subject_type,
+                    'id' => $link->subject_id,
+                    'role' => $link->role,
+                    'title' => $presents
+                        ? $subject->ticketSubjectTitle()
+                        : (is_string($subject?->name ?? null) ? $subject->name : class_basename($link->subject_type).' #'.$link->subject_id),
+                    'subtitle' => $presents ? $subject->ticketSubjectSubtitle() : null,
+                    'url' => $presents ? $subject->ticketSubjectUrl() : null,
+                    'color' => $presents ? $subject->ticketSubjectColor() : null,
+                    'icon' => $presents ? $subject->ticketSubjectIcon() : null,
+                    'missing' => $subject === null,
+                ];
+            })->values()),
             'replies' => $this->whenLoaded('replies', fn () => ReplyResource::collection($this->replies)),
             'activities' => $this->whenLoaded('activities', fn () => $this->activities->map(fn ($a) => [
                 'id' => $a->id,

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -144,6 +144,62 @@ class Ticket extends Model
         return $this->morphMany(Attachment::class, 'attachable');
     }
 
+    /**
+     * The host-app entities this ticket is about (Project, Customer, …),
+     * each resolvable via `$link->subject`.
+     */
+    public function subjects(): HasMany
+    {
+        return $this->hasMany(TicketSubjectLink::class, 'ticket_id')->orderBy('position');
+    }
+
+    /**
+     * Attach a host model as a subject of this ticket (idempotent on the
+     * ticket+type+id key). Rejects types outside the configured allowlist when
+     * one is set (see config `escalated.ticket_subjects.types`).
+     */
+    public function attachSubject(Model $subject, ?string $role = null, ?int $position = null): TicketSubjectLink
+    {
+        $type = $subject->getMorphClass();
+
+        $allowed = (array) config('escalated.ticket_subjects.types', []);
+        if ($allowed !== [] && ! in_array($type, $allowed, true)) {
+            throw new \InvalidArgumentException("Subject type [{$type}] is not an allowed ticket subject.");
+        }
+
+        return $this->subjects()->updateOrCreate(
+            ['subject_type' => $type, 'subject_id' => (string) $subject->getKey()],
+            ['role' => $role, 'position' => $position ?? ($this->subjects()->max('position') + 1)],
+        );
+    }
+
+    /**
+     * Detach a host model from this ticket's subjects. Returns the number of
+     * links removed (0 or 1).
+     */
+    public function detachSubject(Model $subject): int
+    {
+        return $this->subjects()
+            ->where('subject_type', $subject->getMorphClass())
+            ->where('subject_id', (string) $subject->getKey())
+            ->delete();
+    }
+
+    /**
+     * Replace this ticket's subjects with the given host models, preserving
+     * order. Accepts an iterable of Models or [Model, role] pairs.
+     */
+    public function syncSubjects(iterable $subjects): void
+    {
+        $this->subjects()->delete();
+
+        $position = 0;
+        foreach ($subjects as $entry) {
+            [$subject, $role] = is_array($entry) ? [$entry[0], $entry[1] ?? null] : [$entry, null];
+            $this->attachSubject($subject, $role, $position++);
+        }
+    }
+
     public function tags(): BelongsToMany
     {
         return $this->belongsToMany(Tag::class, Escalated::table('ticket_tag'), 'ticket_id', 'tag_id');

--- a/src/Models/TicketSubjectLink.php
+++ b/src/Models/TicketSubjectLink.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Escalated\Laravel\Models;
+
+use Escalated\Laravel\Contracts\TicketSubject;
+use Escalated\Laravel\Escalated;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Join row linking a ticket to one host-app subject model. The `subject`
+ * relation resolves polymorphically to the attached host model (a Project,
+ * Customer, …), which should implement
+ * {@see TicketSubject}.
+ */
+class TicketSubjectLink extends Model
+{
+    protected $guarded = ['id'];
+
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+        ];
+    }
+
+    public function getTable(): string
+    {
+        return Escalated::table('ticket_subjects');
+    }
+
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(Ticket::class, 'ticket_id');
+    }
+
+    public function subject(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/Feature/TicketSubjectTest.php
+++ b/tests/Feature/TicketSubjectTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use Escalated\Laravel\Concerns\PresentsAsTicketSubject;
+use Escalated\Laravel\Contracts\TicketSubject;
+use Escalated\Laravel\Http\Resources\TicketResource;
+use Escalated\Laravel\Models\Ticket;
+use Escalated\Laravel\Models\TicketSubjectLink;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// A host-app model that opts into being a ticket subject. Uses a STRING primary
+// key to also prove subject_id is host-key-type agnostic (int/uuid/string).
+class FakeProject extends Model implements TicketSubject
+{
+    use PresentsAsTicketSubject;
+
+    protected $table = 'fake_projects';
+
+    protected $guarded = [];
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $timestamps = false;
+
+    public function ticketSubjectSubtitle(): ?string
+    {
+        return 'Project · '.$this->account;
+    }
+
+    public function ticketSubjectUrl(): ?string
+    {
+        return 'https://app.test/projects/'.$this->getKey();
+    }
+
+    public function ticketSubjectColor(): ?string
+    {
+        return '#2563eb';
+    }
+
+    public function ticketSubjectIcon(): ?string
+    {
+        return 'folder';
+    }
+}
+
+beforeEach(function () {
+    Schema::create('fake_projects', function (Blueprint $table) {
+        $table->string('id')->primary();
+        $table->string('name');
+        $table->string('account')->nullable();
+    });
+
+    config()->set('escalated.ticket_subjects.types', [FakeProject::class]);
+});
+
+afterEach(fn () => Schema::dropIfExists('fake_projects'));
+
+it('attaches a host model as a ticket subject, preserving a string key', function () {
+    $ticket = Ticket::factory()->create();
+    $project = FakeProject::create(['id' => 'prj_9f1c', 'name' => 'Acme Redesign', 'account' => 'Acme']);
+
+    $link = $ticket->attachSubject($project, 'project');
+
+    expect($link)->toBeInstanceOf(TicketSubjectLink::class)
+        ->and($ticket->subjects()->count())->toBe(1)
+        ->and($link->subject_type)->toBe(FakeProject::class)
+        ->and($link->subject_id)->toBe('prj_9f1c')
+        ->and($link->role)->toBe('project')
+        ->and($link->subject->is($project))->toBeTrue();
+});
+
+it('is idempotent on the ticket+type+id key and updates the role', function () {
+    $ticket = Ticket::factory()->create();
+    $project = FakeProject::create(['id' => 'p1', 'name' => 'A']);
+
+    $ticket->attachSubject($project);
+    $ticket->attachSubject($project, 'account');
+
+    expect($ticket->subjects()->count())->toBe(1)
+        ->and($ticket->subjects()->first()->role)->toBe('account');
+});
+
+it('serializes subjects through the presentation contract', function () {
+    $ticket = Ticket::factory()->create();
+    $project = FakeProject::create(['id' => '7', 'name' => 'Acme Redesign', 'account' => 'Acme']);
+    $ticket->attachSubject($project, 'project');
+
+    $data = (new TicketResource($ticket->load('subjects.subject')))->toArray(request());
+
+    expect($data['subjects'])->toHaveCount(1);
+    expect($data['subjects'][0])->toMatchArray([
+        'type' => FakeProject::class,
+        'id' => '7',
+        'role' => 'project',
+        'title' => 'Acme Redesign',
+        'subtitle' => 'Project · Acme',
+        'url' => 'https://app.test/projects/7',
+        'color' => '#2563eb',
+        'icon' => 'folder',
+        'missing' => false,
+    ]);
+});
+
+it('detaches a subject', function () {
+    $ticket = Ticket::factory()->create();
+    $project = FakeProject::create(['id' => '1', 'name' => 'A']);
+    $ticket->attachSubject($project);
+
+    expect($ticket->detachSubject($project))->toBe(1)
+        ->and($ticket->subjects()->count())->toBe(0);
+});
+
+it('syncs subjects, replacing existing and preserving order', function () {
+    $ticket = Ticket::factory()->create();
+    $a = FakeProject::create(['id' => 'a', 'name' => 'A']);
+    $b = FakeProject::create(['id' => 'b', 'name' => 'B']);
+    $c = FakeProject::create(['id' => 'c', 'name' => 'C']);
+
+    $ticket->attachSubject($a);
+    $ticket->syncSubjects([[$b, 'primary'], $c]);
+
+    $links = $ticket->subjects()->get();
+    expect($links)->toHaveCount(2)
+        ->and($links[0]->subject_id)->toBe('b')
+        ->and($links[0]->role)->toBe('primary')
+        ->and($links[0]->position)->toBe(0)
+        ->and($links[1]->subject_id)->toBe('c')
+        ->and($links[1]->position)->toBe(1);
+});
+
+it('rejects attaching a type outside the configured allowlist', function () {
+    config()->set('escalated.ticket_subjects.types', ['App\\Models\\SomethingElse']);
+
+    $ticket = Ticket::factory()->create();
+    $project = FakeProject::create(['id' => '1', 'name' => 'A']);
+
+    expect(fn () => $ticket->attachSubject($project))->toThrow(InvalidArgumentException::class);
+});
+
+it('allows any model programmatically when no allowlist is configured', function () {
+    config()->set('escalated.ticket_subjects.types', []);
+
+    $ticket = Ticket::factory()->create();
+    $project = FakeProject::create(['id' => '1', 'name' => 'A']);
+
+    expect($ticket->attachSubject($project))->toBeInstanceOf(TicketSubjectLink::class);
+});


### PR DESCRIPTION
Implements the "Ticket Subject / attachable models" feature from discussion #89.

A ticket already has a **requester** (the person who raised it) and a **subject line** (free text). This adds a third concept: the host-app **entities a ticket is about** — a Project, Customer, Lead, asset — which aren't people, each rendered in the ticket UI via a presentation contract. Per the discussion, a ticket can reference **several** heterogeneous models.

## What's included

- **Contract `Escalated\Laravel\Contracts\TicketSubject`** — host models implement `ticketSubjectTitle/Subtitle/Url/Color/Icon()`. A **`PresentsAsTicketSubject` trait** supplies sane defaults (title from `name`/`title`, rest null) so models opt in with one line.
- **Schema** — `escalated_ticket_subjects` pivot (polymorphic `subject_type`/`subject_id`, `role` label, `position`, cascade on ticket delete). `subject_id` is a **string** so integer, UUID, or string-keyed host models all attach cleanly.
- **`TicketSubjectLink` model** + `Ticket::subjects()` relation and `attachSubject()` / `detachSubject()` / `syncSubjects()` helpers (idempotent on ticket+type+id; ordered).
- **Serialization** — `TicketResource` gains a `subjects[]` block (`type, id, role, title, subtitle, url, color, icon, missing`) built from the contract, with graceful fallback when a model doesn't implement it or was deleted. Additive — null/absent for tickets with no subjects, so fully backward-compatible.
- **Agent endpoints** — `POST /…/tickets/{ticket}/subjects` and `DELETE /…/tickets/{ticket}/subjects/{subject}`. Types are resolved **strictly against the `escalated.ticket_subjects.types` allowlist**, so request input can never instantiate an arbitrary class. Programmatic `attachSubject()` works for any model when no allowlist is set.

## Usage

```php
class Project extends Model implements TicketSubject {
    use PresentsAsTicketSubject;
    public function ticketSubjectSubtitle(): ?string { return 'Project · '.$this->customer->name; }
    public function ticketSubjectUrl(): ?string { return route('projects.show', $this); }
}

$ticket->attachSubject($project, role: 'project');
$ticket->syncSubjects([$project, [$customer, 'account']]);
```

## Scope / follow-ups

- This is the **Laravel reference** (per the discussion). The shared-frontend "Subject" card (`escalated` repo) and the other backends follow once this is reviewed — same pattern as the UUID / newsletter rollouts.
- Naming note: the relation is `subjects()` and the contract `TicketSubject` (host-implemented); the join model is `TicketSubjectLink` to avoid colliding with the ticket's `subject` text attribute and the existing `attachable` (file Attachments) morph.

## Tests

New `tests/Feature/TicketSubjectTest.php` (7 tests): attach with a string key, idempotency + role update, contract serialization, detach, sync/ordering, allowlist rejection, no-allowlist programmatic attach. Full suite green locally (193 Ticket-matched tests pass, no regressions); Pint clean.
