### PR TITLE
fix(replies): include real author in ReplyCreated broadcast payload

### DIFF
--- a/src/Events/ReplyCreated.php
+++ b/src/Events/ReplyCreated.php
@@ -29,13 +29,26 @@ class ReplyCreated implements ShouldBroadcastNow
 
     public function broadcastWith(): array
     {
+        // The author is a polymorphic Ticketable (author_type/author_id), not a
+        // `user` — read it from the `author` relation. Prefer the Ticketable
+        // display name so both Users and Contacts resolve, falling back to a
+        // plain `name` attribute.
+        $author = $this->reply->author;
+        $authorName = $author?->ticketable_name ?? $author?->name;
+
         return [
             'reply_id' => $this->reply->id,
             'ticket_id' => $this->reply->ticket_id,
             'body' => $this->reply->body,
             'is_internal_note' => (bool) $this->reply->is_internal_note,
-            'author_id' => $this->reply->user_id,
-            'author_name' => $this->reply->user?->name ?? null,
+            'author_id' => $author?->getKey(),
+            'author_name' => $authorName,
+            // Nested shape mirrors ReplyResource so a real-time consumer can
+            // render reply.author.name without a server round-trip.
+            'author' => $author ? [
+                'id' => $author->getKey(),
+                'name' => $authorName,
+            ] : null,
             'created_at' => $this->reply->created_at?->toISOString(),
         ];
     }

--- a/tests/Feature/ReplyCreatedBroadcastTest.php
+++ b/tests/Feature/ReplyCreatedBroadcastTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Escalated\Laravel\Events\ReplyCreated;
+use Escalated\Laravel\Models\Ticket;
+
+// Regression: the real-time `.reply.created` payload must carry the reply's
+// author. It previously read $reply->user_id / $reply->user (which don't exist
+// on Reply — it uses the polymorphic author_type/author_id), so every payload
+// shipped author_id/author_name = null → "Unknown" in the UI.
+
+it('includes the real author in the ReplyCreated broadcast payload', function () {
+    $agent = $this->createAgent(['name' => 'Dana Agent']);
+    $ticket = Ticket::factory()->create();
+
+    $reply = $ticket->addReply($agent, 'On it!');
+
+    $payload = (new ReplyCreated($reply))->broadcastWith();
+
+    expect($payload['author_id'])->toEqual($agent->getKey())
+        ->and($payload['author_name'])->toBe('Dana Agent')
+        ->and($payload['author'])->toMatchArray([
+            'id' => $agent->getKey(),
+            'name' => 'Dana Agent',
+        ]);
+});
+
+it('emits a null author for an unauthored (system) reply', function () {
+    $ticket = Ticket::factory()->create();
+
+    $reply = $ticket->replies()->create([
+        'ticket_id' => $ticket->id,
+        'author_type' => null,
+        'author_id' => null,
+        'body' => 'Automated system message',
+        'is_internal_note' => false,
+        'type' => 'reply',
+    ]);
+
+    $payload = (new ReplyCreated($reply))->broadcastWith();
+
+    expect($payload['author_id'])->toBeNull()
+        ->and($payload['author_name'])->toBeNull()
+        ->and($payload['author'])->toBeNull();
+});


### PR DESCRIPTION
Closes #123.

`ReplyCreated::broadcastWith()` read `\->user_id` and `\->user?->name` — fields that don't exist on `Reply` (it stores its author as a polymorphic `author_type`/`author_id` + `author()` morphTo, set in `Ticket::addReply()`). So every `.reply.created` payload shipped `author_id`/`author_name` = `null`, rendering **'Unknown'** in the shared `ReplyThread.vue` for any consumer of the real-time event.

**Fix:** read the author from the `author` relation, using the Ticketable display name (so Users *and* Contacts resolve), and add a nested `author { id, name }` mirroring `ReplyResource` so a real-time consumer can render `reply.author.name` without a round-trip. Null author for system replies.

**Why backend, not a frontend stamp:** this is the response *shape* — fixing it here means mobile / widget / side-conversation / third-party listeners all benefit (the agent web page already reloads correct data via `show()`; the broadcast payload was the broken surface).

**Tests:** `tests/Feature/ReplyCreatedBroadcastTest.php` — payload includes the real `author_id`/`author_name`/`author` for an agent reply, and `null` for a system reply. Pest green, Pint clean.

Frontend regression test (shared `ReplyThread.vue`): escalated-dev/escalated PR (`fix/reply-thread-author-test`). Other backend ports broadcast the same event shape and should be checked for the same bug in a follow-up.