### PR TITLE
ci: set least-privilege permissions on run-tests workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+# Least-privilege GITHUB_TOKEN: the test job only needs to read the repo.
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds an explicit least-privilege `permissions` block to `.github/workflows/laravel.yml`:

```yaml
permissions:
  contents: read
```

## Why

CodeQL (`actions/missing-workflow-permissions`) flagged the `run-tests` workflow for having no explicit `permissions` block. Without one, `GITHUB_TOKEN` inherits the repository default, which is frequently read/write — more scope than the job needs.

The `tests` job only checks out the repo and runs Pest, so `contents: read` is sufficient.

## Scope check

- `lint.yml` already declares `contents: write` (required for the Pint auto-commit step).
- `fossa.yml` already declares `contents: read`.

`laravel.yml` was the only workflow missing an explicit scope; this brings it in line.

No functional change to the test matrix.