### PR TITLE
feat(workflow): add_follower action - auto-subscribe ticket followers

### DIFF
--- a/src/Http/Controllers/Admin/WorkflowController.php
+++ b/src/Http/Controllers/Admin/WorkflowController.php
@@ -41,7 +41,7 @@ class WorkflowController extends Controller
             'trigger_event' => 'required|string',
             'conditions' => 'required|array',
             'actions' => 'required|array|min:1',
-            'actions.*.type' => 'required|string|in:assign_agent,change_status,change_priority,add_tag,remove_tag,move_department,add_internal_note,send_notification,send_webhook,apply_macro,close_ticket,snooze_ticket,delay',
+            'actions.*.type' => 'required|string|in:assign_agent,change_status,change_priority,add_tag,remove_tag,move_department,add_internal_note,send_notification,send_webhook,apply_macro,close_ticket,snooze_ticket,delay,add_follower',
             'description' => 'nullable|string',
             'is_active' => 'boolean',
         ]);
@@ -84,7 +84,7 @@ class WorkflowController extends Controller
             'trigger_event' => 'required|string',
             'conditions' => 'required|array',
             'actions' => 'required|array|min:1',
-            'actions.*.type' => 'required|string|in:assign_agent,change_status,change_priority,add_tag,remove_tag,move_department,add_internal_note,send_notification,send_webhook,apply_macro,close_ticket,snooze_ticket,delay',
+            'actions.*.type' => 'required|string|in:assign_agent,change_status,change_priority,add_tag,remove_tag,move_department,add_internal_note,send_notification,send_webhook,apply_macro,close_ticket,snooze_ticket,delay,add_follower',
             'description' => 'nullable|string',
             'is_active' => 'boolean',
         ]);

--- a/src/Services/WorkflowEngine.php
+++ b/src/Services/WorkflowEngine.php
@@ -308,6 +308,7 @@ class WorkflowEngine
             'apply_macro' => $this->actionApplyMacro($ticket, $value),
             'close_ticket' => $this->actionCloseTicket($ticket),
             'snooze_ticket' => $this->actionSnoozeTicket($ticket, $value),
+            'add_follower' => $this->actionAddFollower($ticket, $value),
             default => Log::warning("Escalated workflow: unknown action type '{$type}'", [
                 'workflow_id' => $workflow->id,
                 'ticket_id' => $ticket->id,
@@ -333,6 +334,24 @@ class WorkflowEngine
         } else {
             $ticket->update(['assigned_to' => $value]);
         }
+    }
+
+    /**
+     * Add a host-app user as a follower of the ticket. The value is a host
+     * user key; it is trimmed and skipped when empty/"0", mirroring
+     * assign_agent. Ticket::follow() uses syncWithoutDetaching, so adding the
+     * same follower twice is a harmless no-op.
+     */
+    protected function actionAddFollower(Ticket $ticket, mixed $value): void
+    {
+        $userId = is_array($value) ? ($value['user_id'] ?? null) : $value;
+        $userId = is_string($userId) ? trim($userId) : $userId;
+
+        if ($userId === null || $userId === '' || $userId === '0' || $userId === 0) {
+            return;
+        }
+
+        $ticket->follow($userId);
     }
 
     protected function findLeastBusyAgent(): ?int

--- a/tests/Unit/WorkflowEngineTest.php
+++ b/tests/Unit/WorkflowEngineTest.php
@@ -273,6 +273,51 @@ it('executes add_tag action', function () {
     expect($ticket->fresh()->tags->pluck('name')->toArray())->toContain('escalated-billing');
 });
 
+it('executes add_follower action', function () {
+    $ticket = Ticket::factory()->create();
+    $follower = $this->createTestUser();
+    $workflow = Workflow::create([
+        'name' => 'Test',
+        'trigger_event' => 'ticket.created',
+        'conditions' => [],
+        'actions' => [],
+        'is_active' => true,
+        'position' => 0,
+    ]);
+
+    $this->engine->executeAction($workflow, $ticket, [
+        'type' => 'add_follower',
+        'value' => $follower->getKey(),
+    ]);
+
+    expect($ticket->fresh()->isFollowedBy($follower->getKey()))->toBeTrue();
+
+    // Idempotent: following again must not create a duplicate pivot row.
+    $this->engine->executeAction($workflow, $ticket, [
+        'type' => 'add_follower',
+        'value' => $follower->getKey(),
+    ]);
+
+    expect($ticket->followers()->count())->toBe(1);
+});
+
+it('skips add_follower with an empty user id', function () {
+    $ticket = Ticket::factory()->create();
+    $workflow = Workflow::create([
+        'name' => 'Test',
+        'trigger_event' => 'ticket.created',
+        'conditions' => [],
+        'actions' => [],
+        'is_active' => true,
+        'position' => 0,
+    ]);
+
+    $this->engine->executeAction($workflow, $ticket, ['type' => 'add_follower', 'value' => '']);
+    $this->engine->executeAction($workflow, $ticket, ['type' => 'add_follower', 'value' => '0']);
+
+    expect($ticket->followers()->count())->toBe(0);
+});
+
 it('executes remove_tag action', function () {
     $ticket = Ticket::factory()->create();
     $tag = Tag::create(['name' => 'remove-me', 'color' => '#000']);


### PR DESCRIPTION
Ports the `add_follower` workflow action from the NestJS reference (escalated-dev/escalated-nestjs#61) to Laravel, realizing escalated-dev discussion #88 ("auto-add followers to department tickets") via the existing event-driven Workflow system.

## How you'd use it

A Workflow with trigger `ticket.created`, condition `departmentId equals <id>`, and action `add_follower` (value = a host user id) auto-subscribes that user to every ticket opened in the department — no host code.

## What's in it

Laravel already has the `ticket_followers` pivot + `Ticket::follow()` (which uses `syncWithoutDetaching`, so it's idempotent), so this is just wiring:

- `WorkflowEngine::executeAction()` — new `add_follower` case → `actionAddFollower()`, which trims the value and skips empty/`"0"` (mirroring `assign_agent`), then calls `$ticket->follow($userId)`.
- `WorkflowController` — `add_follower` added to the `actions.*.type` allowlist on store + update so the action validates.

No migration needed (the followers table already exists). uuid/string user keys are handled (the value is passed through as-is, same as `assign_agent`).

## Tests

`tests/Unit/WorkflowEngineTest.php`: follows a user, idempotent no-op on a second add (pivot count stays 1), and empty/`"0"` is skipped.

`php vendor/bin/pest --filter=WorkflowEngine` → **49 passed**. Pint clean.

## Follow-ups (not here)

- Add `add_follower` to the shared frontend workflow-action catalog so it's offered in the builder UI (currently configurable via API/import, like on the NestJS reference).
- Continue the fan-out to the remaining host backends.
