### PR TITLE
fix(newsletter): UUID-safe user-id columns in newsletter migrations

### DIFF
--- a/database/migrations/2026_05_19_000001_create_escalated_newsletter_lists_table.php
+++ b/database/migrations/2026_05_19_000001_create_escalated_newsletter_lists_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
             $table->text('description')->nullable();
             $table->enum('kind', ['static', 'dynamic']);
             $table->json('filter_json')->nullable();
-            $table->unsignedBigInteger('created_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
             $table->timestamps();
 
             $table->index('kind');

--- a/database/migrations/2026_05_19_000002_create_escalated_newsletter_list_members_table.php
+++ b/database/migrations/2026_05_19_000002_create_escalated_newsletter_list_members_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
             $table->unsignedBigInteger('list_id');
             $table->unsignedBigInteger('contact_id');
             $table->timestamp('added_at')->useCurrent();
-            $table->unsignedBigInteger('added_by')->nullable();
+            Escalated::userForeignColumn($table, 'added_by')->nullable();
 
             $table->unique(['list_id', 'contact_id']);
             $table->index('contact_id');

--- a/database/migrations/2026_05_19_000003_create_escalated_newsletter_templates_table.php
+++ b/database/migrations/2026_05_19_000003_create_escalated_newsletter_templates_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +16,7 @@ return new class extends Migration
             $table->string('subject_template', 998)->nullable();
             $table->text('body_markdown');
             $table->json('merge_fields_schema')->nullable();
-            $table->unsignedBigInteger('created_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
             $table->timestamps();
 
             $table->index('theme');

--- a/database/migrations/2026_05_19_000004_create_escalated_newsletters_table.php
+++ b/database/migrations/2026_05_19_000004_create_escalated_newsletters_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Escalated\Laravel\Escalated;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -21,8 +22,8 @@ return new class extends Migration
             $table->enum('status', ['draft', 'scheduled', 'sending', 'sent', 'paused', 'failed'])->default('draft');
             $table->timestamp('scheduled_at')->nullable();
             $table->timestamp('sent_at')->nullable();
-            $table->unsignedBigInteger('created_by')->nullable();
-            $table->unsignedBigInteger('sent_by')->nullable();
+            Escalated::userForeignColumn($table, 'created_by')->nullable();
+            Escalated::userForeignColumn($table, 'sent_by')->nullable();
             $table->unsignedInteger('summary_total')->default(0);
             $table->unsignedInteger('summary_sent')->default(0);
             $table->unsignedInteger('summary_opened')->default(0);


### PR DESCRIPTION
Newsletter `created_by`/`added_by`/`sent_by` used `unsignedBigInteger`, reintroducing the integer-only host-user-key assumption. Switches them to `Escalated::userForeignColumn` (`unsignedBigInteger` by default — identical schema for integer-keyed hosts; `uuid`/`ulid`/`string` for those hosts), consistent with `ticket_followers.user_id` and `tickets.assigned_to`. FK columns (`list_id`/`contact_id`/`template_id`) stay `bigint`. 35 newsletter tests pass; Pint clean.