### PR TITLE
feat(newsletters): enforce newsletters.manage/.send on admin routes

### DIFF
--- a/src/EscalatedServiceProvider.php
+++ b/src/EscalatedServiceProvider.php
@@ -444,6 +444,7 @@ class EscalatedServiceProvider extends ServiceProvider
                 'prefix' => config('escalated.routes.prefix', 'support'),
                 'is_agent' => $user ? Gate::allows('escalated-agent', $user) : false,
                 'is_admin' => $user ? Gate::allows('escalated-admin', $user) : false,
+                'permissions' => $user ? CheckPermission::userPermissions($user->getKey()) : [],
                 'features' => [
                     'newsletters' => (bool) config('escalated.enable_newsletters', false),
                 ],

--- a/src/EscalatedServiceProvider.php
+++ b/src/EscalatedServiceProvider.php
@@ -21,6 +21,7 @@ use Escalated\Laravel\Console\Commands\RunAutomationsCommand;
 use Escalated\Laravel\Console\Commands\WakeSnoozedTicketsCommand;
 use Escalated\Laravel\Contracts\EscalatedUiRenderer;
 use Escalated\Laravel\Http\Controllers\Admin\ApiTokenController;
+use Escalated\Laravel\Http\Middleware\CheckPermission;
 use Escalated\Laravel\Http\Middleware\EnsureIsAdmin;
 use Escalated\Laravel\Models\AgentProfile;
 use Escalated\Laravel\Models\EscalatedSettings;
@@ -128,7 +129,7 @@ class EscalatedServiceProvider extends ServiceProvider
             return;
         }
 
-        Route::middleware(['web', EnsureIsAdmin::class])
+        Route::middleware(['web', EnsureIsAdmin::class, CheckPermission::class.':newsletters.manage'])
             ->prefix('admin/newsletters')
             ->name('escalated.admin.newsletters.')
             ->group(__DIR__.'/../routes/newsletter-admin.php');

--- a/src/Http/Controllers/Admin/NewsletterController.php
+++ b/src/Http/Controllers/Admin/NewsletterController.php
@@ -3,6 +3,7 @@
 namespace Escalated\Laravel\Http\Controllers\Admin;
 
 use Escalated\Laravel\Contracts\EscalatedUiRenderer;
+use Escalated\Laravel\Http\Middleware\CheckPermission;
 use Escalated\Laravel\Models\Contact;
 use Escalated\Laravel\Models\Newsletter\Newsletter;
 use Escalated\Laravel\Models\Newsletter\NewsletterDelivery;
@@ -19,6 +20,19 @@ use Illuminate\Support\Str;
 class NewsletterController extends Controller
 {
     public function __construct(protected EscalatedUiRenderer $ui) {}
+
+    /**
+     * Gate send-class actions behind the newsletters.send permission.
+     * (newsletters.manage is enforced on the whole admin route group.)
+     */
+    private function requireSendPermission(): void
+    {
+        abort_unless(
+            CheckPermission::userHasPermission(Auth::id(), 'newsletters.send'),
+            403,
+            'You do not have the required permission: newsletters.send'
+        );
+    }
 
     public function index(Request $request): mixed
     {
@@ -42,6 +56,9 @@ class NewsletterController extends Controller
     {
         $data = $this->validateForm($request);
         $isSend = in_array($data['status'] ?? 'draft', ['scheduled', 'sending'], true);
+        if ($isSend) {
+            $this->requireSendPermission();
+        }
         if ($isSend && ! $this->mailConfigured()) {
             return back()->withErrors(['from_email' => 'Outbound mail is not configured.']);
         }
@@ -82,6 +99,9 @@ class NewsletterController extends Controller
     public function update(Newsletter $newsletter, Request $request, NewsletterPlannerService $planner): mixed
     {
         $data = $this->validateForm($request);
+        if (in_array($data['status'] ?? 'draft', ['scheduled', 'sending'], true)) {
+            $this->requireSendPermission();
+        }
         $newsletter->update($data);
         if (($data['status'] ?? null) === 'sending') {
             $planner->plan($newsletter);
@@ -123,6 +143,7 @@ class NewsletterController extends Controller
 
     public function testSend(Request $request, NewsletterRendererService $renderer): mixed
     {
+        $this->requireSendPermission();
         $data = $this->validateForm($request);
         $n = new Newsletter($data);
         $n->id = 0;

--- a/src/Http/Middleware/CheckPermission.php
+++ b/src/Http/Middleware/CheckPermission.php
@@ -34,4 +34,26 @@ class CheckPermission
             ->where(Escalated::table('permissions').'.slug', $permissionSlug)
             ->exists();
     }
+
+    /**
+     * All permission slugs granted to the user (via their roles).
+     * Returns [] if the permission tables are not present yet.
+     *
+     * @return list<string>
+     */
+    public static function userPermissions(int|string $userId): array
+    {
+        try {
+            return DB::table(Escalated::table('role_user'))
+                ->join(Escalated::table('role_permission'), Escalated::table('role_user').'.role_id', '=', Escalated::table('role_permission').'.role_id')
+                ->join(Escalated::table('permissions'), Escalated::table('role_permission').'.permission_id', '=', Escalated::table('permissions').'.id')
+                ->where(Escalated::table('role_user').'.user_id', $userId)
+                ->pluck(Escalated::table('permissions').'.slug')
+                ->unique()
+                ->values()
+                ->all();
+        } catch (\Throwable) {
+            return [];
+        }
+    }
 }

--- a/src/Http/Middleware/CheckPermission.php
+++ b/src/Http/Middleware/CheckPermission.php
@@ -18,14 +18,14 @@ class CheckPermission
             abort(403, 'Unauthorized.');
         }
 
-        if ($this->userHasPermission($user->id, $permission)) {
+        if (self::userHasPermission($user->id, $permission)) {
             return $next($request);
         }
 
         abort(403, 'You do not have the required permission: '.$permission);
     }
 
-    protected function userHasPermission(int|string $userId, string $permissionSlug): bool
+    public static function userHasPermission(int|string $userId, string $permissionSlug): bool
     {
         return DB::table(Escalated::table('role_user'))
             ->join(Escalated::table('role_permission'), Escalated::table('role_user').'.role_id', '=', Escalated::table('role_permission').'.role_id')


### PR DESCRIPTION
## What

Closes the audit gap where the newsletter permissions were **seeded but never enforced** — any admin-role user could perform every newsletter action regardless of their assigned permissions. Laravel was the last backend not enforcing the slugs it seeds (Django/Rails/NestJS/etc. already do).

## Changes
- **Admin route group** now applies `CheckPermission:newsletters.manage` (in addition to `web` + `EnsureIsAdmin`), so every admin newsletter route requires `newsletters.manage`.
- **`newsletters.send`** is enforced on the send-class actions, matching the contract + the other backends:
  - `store` / `update` when the status is `scheduled` or `sending`
  - `testSend` (always)
- `CheckPermission::userHasPermission()` made `public static` so the controller can reuse the exact same role→permission check the middleware uses (no duplicated logic).

## Verification
- Existing newsletter suite: **35 passed** (service-level tests, unaffected — confirmed no regression).
- `vendor/bin/pint --dirty`: clean. `php -l` clean on all changed files.

## Follow-up
An HTTP-layer feature test for this enforcement (403 without the permission, 200 with) is recommended — the repo currently has **no** HTTP/controller-layer newsletter tests, and adding one needs boot-time-flag + role/permission test scaffolding that doesn't exist yet. Worth a dedicated test-infra pass.