### PR TITLE
feat: configurable DB connection for Escalated models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `escalated.database_connection` config (env: `ESCALATED_DB_CONNECTION`) — routes every Escalated Eloquent model to a named Laravel connection. Useful for multi-database tenant apps where Escalated's tables live in a per-tenant DB. Per-model `$connection` overrides still take precedence; leaving the config unset preserves prior behavior.
+
 ## [1.5.1] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ All config lives in `config/escalated.php`. Key options:
 ```php
 'mode' => 'self-hosted',              // self-hosted | synced | cloud
 'user_model' => App\Models\User::class,
+'database_connection' => null,        // Route Escalated models to a non-default DB connection
 'table_prefix' => 'escalated_',
 'default_priority' => 'medium',
 
@@ -443,6 +444,22 @@ All config lives in `config/escalated.php`. Key options:
 ```
 
 See the [full configuration reference](docs/configuration.md).
+
+### Multi-database tenant apps
+
+Set `escalated.database_connection` (or `ESCALATED_DB_CONNECTION`) to the
+Laravel connection name where Escalated's tables live. All Escalated
+models will route their queries through it. Useful when each tenant has
+its own database and Escalated's tables ship in the per-tenant DB
+alongside the rest of the tenant-scoped data.
+
+```env
+ESCALATED_DB_CONNECTION=tenant
+```
+
+Per-model `$connection` overrides still take precedence, so a host app
+or subclass can pin individual models independently. Leave the config
+unset to keep Laravel's default behavior.
 
 ## Events
 

--- a/config/escalated.php
+++ b/config/escalated.php
@@ -55,6 +55,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | The Laravel database connection Escalated models should query. Leave
+    | null to use the application's default connection (no behavior change
+    | from previous versions). Set to a named connection — most commonly
+    | useful for multi-database tenant setups where each tenant has its
+    | own database and Escalated's tables live there alongside other
+    | tenant-scoped data.
+    |
+    | Per-model `$connection` overrides still take precedence, so a host
+    | app or a subclass can pin individual models independently.
+    |
+    */
+    'database_connection' => env('ESCALATED_DB_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Hosted / Cloud Configuration
     |--------------------------------------------------------------------------
     */

--- a/src/Concerns/UsesEscalatedConnection.php
+++ b/src/Concerns/UsesEscalatedConnection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Escalated\Laravel\Concerns;
+
+/**
+ * Routes Escalated Eloquent models to a configurable database connection.
+ *
+ * Hosts that store Escalated tables on a non-default connection — most
+ * commonly a multi-database multi-tenant setup where each tenant has
+ * its own DB — set {@see escalated.database_connection} to that
+ * connection name (or `ESCALATED_DB_CONNECTION` env var). All Escalated
+ * models then route their queries through it.
+ *
+ * Per-model `$connection` overrides still win, so subclasses or
+ * specific models can opt out by setting `protected $connection`.
+ * Hosts that leave the config null see the default Laravel behavior
+ * (no behavior change vs. earlier package versions).
+ */
+trait UsesEscalatedConnection
+{
+    public function getConnectionName(): ?string
+    {
+        return $this->connection ?? config('escalated.database_connection');
+    }
+}

--- a/src/Models/AgentCapacity.php
+++ b/src/Models/AgentCapacity.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AgentCapacity extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/AgentProfile.php
+++ b/src/Models/AgentProfile.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Enums\ChatStatus;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AgentProfile extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/ApiToken.php
+++ b/src/Models/ApiToken.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ApiToken extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/Article.php
+++ b/src/Models/Article.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Article extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/ArticleCategory.php
+++ b/src/Models/ArticleCategory.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class ArticleCategory extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -9,6 +10,8 @@ use Illuminate\Support\Facades\Storage;
 
 class Attachment extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected $appends = ['url'];

--- a/src/Models/AuditLog.php
+++ b/src/Models/AuditLog.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class AuditLog extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public $timestamps = false;

--- a/src/Models/Automation.php
+++ b/src/Models/Automation.php
@@ -2,11 +2,14 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 
 class Automation extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/BusinessSchedule.php
+++ b/src/Models/BusinessSchedule.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class BusinessSchedule extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/CannedResponse.php
+++ b/src/Models/CannedResponse.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\CannedResponseFactory;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -10,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class CannedResponse extends Model
 {
-    use HasFactory;
+    use HasFactory, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/ChatRoutingRule.php
+++ b/src/Models/ChatRoutingRule.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Enums\OfflineBehavior;
 use Escalated\Laravel\Enums\RoutingStrategy;
 use Escalated\Laravel\Escalated;
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ChatRoutingRule extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/ChatSession.php
+++ b/src/Models/ChatSession.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\ChatSessionFactory;
 use Escalated\Laravel\Enums\ChatSessionStatus;
 use Escalated\Laravel\Escalated;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ChatSession extends Model
 {
-    use HasFactory;
+    use HasFactory, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Contact extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected $casts = [

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,6 +10,8 @@ use Illuminate\Support\Str;
 
 class CustomField extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/CustomFieldValue.php
+++ b/src/Models/CustomFieldValue.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class CustomFieldValue extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/CustomObject.php
+++ b/src/Models/CustomObject.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CustomObject extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/CustomObjectRecord.php
+++ b/src/Models/CustomObjectRecord.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class CustomObjectRecord extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/DelayedAction.php
+++ b/src/Models/DelayedAction.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class DelayedAction extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/Department.php
+++ b/src/Models/Department.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\DepartmentFactory;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +13,7 @@ use Illuminate\Support\Str;
 
 class Department extends Model
 {
-    use HasFactory;
+    use HasFactory, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/EscalatedSettings.php
+++ b/src/Models/EscalatedSettings.php
@@ -2,11 +2,14 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 
 class EscalatedSettings extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/EscalationRule.php
+++ b/src/Models/EscalationRule.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\EscalationRuleFactory;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class EscalationRule extends Model
 {
-    use HasFactory;
+    use HasFactory, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/Holiday.php
+++ b/src/Models/Holiday.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Holiday extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/ImportJob.php
+++ b/src/Models/ImportJob.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class ImportJob extends Model
 {
-    use HasUuids;
+    use HasUuids, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/ImportSourceMap.php
+++ b/src/Models/ImportSourceMap.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ImportSourceMap extends Model
 {
+    use UsesEscalatedConnection;
+
     const UPDATED_AT = null;
 
     protected $guarded = ['id'];

--- a/src/Models/InboundEmail.php
+++ b/src/Models/InboundEmail.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class InboundEmail extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/Macro.php
+++ b/src/Models/Macro.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Macro extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/Mention.php
+++ b/src/Models/Mention.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Mention extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/Newsletter/Newsletter.php
+++ b/src/Models/Newsletter/Newsletter.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models\Newsletter;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Newsletter extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $table = 'escalated_newsletters';
 
     protected $fillable = [

--- a/src/Models/Newsletter/NewsletterDelivery.php
+++ b/src/Models/Newsletter/NewsletterDelivery.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models\Newsletter;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Models\Contact;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class NewsletterDelivery extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $table = 'escalated_newsletter_deliveries';
 
     const UPDATED_AT = null;

--- a/src/Models/Newsletter/NewsletterList.php
+++ b/src/Models/Newsletter/NewsletterList.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models\Newsletter;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Models\Contact;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class NewsletterList extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $table = 'escalated_newsletter_lists';
 
     protected $fillable = ['name', 'description', 'kind', 'filter_json', 'created_by'];

--- a/src/Models/Newsletter/NewsletterListMember.php
+++ b/src/Models/Newsletter/NewsletterListMember.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models\Newsletter;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Models\Contact;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class NewsletterListMember extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $table = 'escalated_newsletter_list_members';
 
     public $timestamps = false;

--- a/src/Models/Newsletter/NewsletterTemplate.php
+++ b/src/Models/Newsletter/NewsletterTemplate.php
@@ -2,10 +2,13 @@
 
 namespace Escalated\Laravel\Models\Newsletter;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Illuminate\Database\Eloquent\Model;
 
 class NewsletterTemplate extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $table = 'escalated_newsletter_templates';
 
     protected $fillable = ['name', 'theme', 'subject_template', 'body_markdown', 'merge_fields_schema', 'created_by'];

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Permission extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public $timestamps = false;

--- a/src/Models/Plugin.php
+++ b/src/Models/Plugin.php
@@ -2,11 +2,14 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 
 class Plugin extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $fillable = [
         'slug',
         'is_active',

--- a/src/Models/PluginStoreRecord.php
+++ b/src/Models/PluginStoreRecord.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 
@@ -18,6 +19,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class PluginStoreRecord extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/Reply.php
+++ b/src/Models/Reply.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\ReplyFactory;
 use Escalated\Laravel\Escalated;
 use Escalated\Laravel\Events\InternalNoteAdded;
@@ -16,7 +17,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Reply extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -9,6 +10,8 @@ use Illuminate\Support\Str;
 
 class Role extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/SatisfactionRating.php
+++ b/src/Models/SatisfactionRating.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class SatisfactionRating extends Model
 {
+    use UsesEscalatedConnection;
+
     public $timestamps = false;
 
     protected $guarded = ['id'];

--- a/src/Models/SavedView.php
+++ b/src/Models/SavedView.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class SavedView extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/SideConversation.php
+++ b/src/Models/SideConversation.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SideConversation extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/SideConversationReply.php
+++ b/src/Models/SideConversationReply.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class SideConversationReply extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/Skill.php
+++ b/src/Models/Skill.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -9,6 +10,8 @@ use Illuminate\Support\Str;
 
 class Skill extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/SlaPolicy.php
+++ b/src/Models/SlaPolicy.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\SlaPolicyFactory;
 use Escalated\Laravel\Enums\TicketPriority;
 use Escalated\Laravel\Escalated;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SlaPolicy extends Model
 {
-    use HasFactory;
+    use HasFactory, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Database\Factories\TagFactory;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -11,7 +12,7 @@ use Illuminate\Support\Str;
 
 class Tag extends Model
 {
-    use HasFactory;
+    use HasFactory, UsesEscalatedConnection;
 
     protected $guarded = ['id'];
 

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Contracts\Ticketable;
 use Escalated\Laravel\Database\Factories\TicketFactory;
 use Escalated\Laravel\Enums\ActivityType;
@@ -23,7 +24,7 @@ use Illuminate\Support\Str;
 
 class Ticket extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, UsesEscalatedConnection;
 
     public const TYPES = ['question', 'problem', 'incident', 'task'];
 

--- a/src/Models/TicketActivity.php
+++ b/src/Models/TicketActivity.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Enums\ActivityType;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class TicketActivity extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected $appends = ['created_at_human'];

--- a/src/Models/TicketLink.php
+++ b/src/Models/TicketLink.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TicketLink extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/TicketStatus.php
+++ b/src/Models/TicketStatus.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class TicketStatus extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/TicketSubjectLink.php
+++ b/src/Models/TicketSubjectLink.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Contracts\TicketSubject;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  */
 class TicketSubjectLink extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected function casts(): array

--- a/src/Models/TwoFactor.php
+++ b/src/Models/TwoFactor.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TwoFactor extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/Webhook.php
+++ b/src/Models/Webhook.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Webhook extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/WebhookDelivery.php
+++ b/src/Models/WebhookDelivery.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class WebhookDelivery extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     public function getTable(): string

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -2,6 +2,7 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Workflow extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected $appends = ['trigger'];

--- a/src/Models/WorkflowLog.php
+++ b/src/Models/WorkflowLog.php
@@ -2,12 +2,15 @@
 
 namespace Escalated\Laravel\Models;
 
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
 use Escalated\Laravel\Escalated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class WorkflowLog extends Model
 {
+    use UsesEscalatedConnection;
+
     protected $guarded = ['id'];
 
     protected $appends = [

--- a/tests/Unit/DatabaseConnectionConfigTest.php
+++ b/tests/Unit/DatabaseConnectionConfigTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Escalated\Laravel\Concerns\UsesEscalatedConnection;
+use Escalated\Laravel\Models\Contact;
+use Escalated\Laravel\Models\Department;
+use Escalated\Laravel\Models\Ticket;
+use Illuminate\Database\Eloquent\Model;
+
+it('returns null on Escalated models when escalated.database_connection is unset', function () {
+    config(['escalated.database_connection' => null]);
+
+    expect((new Ticket)->getConnectionName())->toBeNull();
+    expect((new Department)->getConnectionName())->toBeNull();
+    expect((new Contact)->getConnectionName())->toBeNull();
+});
+
+it('routes Escalated models to the configured connection name', function () {
+    config(['escalated.database_connection' => 'tenant']);
+
+    expect((new Ticket)->getConnectionName())->toBe('tenant');
+    expect((new Department)->getConnectionName())->toBe('tenant');
+    expect((new Contact)->getConnectionName())->toBe('tenant');
+});
+
+it('honors a per-model $connection override over the config', function () {
+    config(['escalated.database_connection' => 'tenant']);
+
+    $pinned = new class extends Model
+    {
+        use UsesEscalatedConnection;
+
+        protected $connection = 'reporting';
+    };
+
+    expect($pinned->getConnectionName())->toBe('reporting');
+});


### PR DESCRIPTION
## Summary

Adds a new `escalated.database_connection` config key (env: `ESCALATED_DB_CONNECTION`) that routes every Escalated Eloquent model to a named Laravel connection.

## Motivation

Multi-database tenant apps — where each tenant has its own DB — need every Escalated model to query the tenant connection. Today, the ~54 models under `src/Models/` all `extends Model` directly with no shared base class or config hook, leaving consumers two unappealing options:

1. **Flip Laravel's default `database.default`** at request time — broad blast radius (every other vendor package that doesn't pin its own connection breaks).
2. **Maintain a local patch** that pins `protected $connection` on each Escalated model — survives via `cweagans/composer-patches` but has to be re-rolled on every Escalated upgrade.

This PR adds first-class support so multi-DB tenant apps can opt in without either workaround.

## Design

- New trait `Escalated\Laravel\Concerns\UsesEscalatedConnection` overrides `getConnectionName()` to return `$this->connection ?? config('escalated.database_connection')`.
- The trait is applied to every model under `src/Models/` (54 files; mechanical 2-line addition each — namespace import + `use UsesEscalatedConnection;`).
- New config key `database_connection` in `config/escalated.php`, sourced from `ESCALATED_DB_CONNECTION` env var, defaulting to `null`.
- Per-model `$connection` overrides still win over the config, so a subclass or specific model can opt out independently.

## Backwards compatibility

Zero behavior change for existing users. With the config left null, `getConnectionName()` returns `$this->connection` — which is null on every current vendor model — identical to today's behavior.

## Tests

New `tests/Unit/DatabaseConnectionConfigTest.php` covering:

- Default (config unset) → `getConnectionName()` returns null on Escalated models.
- Config set → models route to the named connection.
- Per-model `$connection` override still wins over the config.

All three pass locally; existing Unit tests on the modified models (`ContactModelTest`, `ChatSessionModelTest`, `DelayedActionTest`, etc.) still pass.

## Test plan

- [ ] CI passes across the Laravel 11/12/13 + PHP 8.2/8.3/8.4 matrix
- [ ] `vendor/bin/pint --test` clean (verified locally — no unrelated style changes)
- [ ] Manual smoke: install in a multi-DB tenant Laravel app, set `ESCALATED_DB_CONNECTION=tenant`, run `Ticket::query()` — queries hit the tenant connection

## Notes

- I went with a shared trait over an `EscalatedModel` abstract base class to avoid forcing a parent-class change on consumers who already subclass models.
- Happy to iterate on the config key name, scope, or implementation approach if you'd prefer something different.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)