### PR TITLE
ci: ignore two new laravel/framework 11.x advisories so the L^11 matrix installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,9 @@
                 "PKSA-8qx3-n5y5-vvnd": "laravel/framework 11.x advisory; CI compat matrix only (see above).",
                 "PKSA-q46n-4fdk-zjr4": "laravel/framework 11.x advisory; CI compat matrix only (see above).",
                 "PKSA-qzrn-rnz3-85w1": "laravel/framework 11.x advisory; CI compat matrix only (see above).",
-                "PKSA-w7xr-vk7n-rstm": "laravel/framework 11.x advisory; CI compat matrix only (see above)."
+                "PKSA-w7xr-vk7n-rstm": "laravel/framework 11.x advisory; CI compat matrix only (see above).",
+                "PKSA-m5cs-t1y6-qpcs": "laravel/framework 11.x advisory; CI compat matrix only (see above).",
+                "PKSA-3r5d-mb8f-1qw9": "laravel/framework 11.x advisory; CI compat matrix only (see above)."
             }
         }
     },


### PR DESCRIPTION
Composer 2.9+ blocks installing advisory-affected packages. Two newly-published `laravel/framework` 11.x advisories (`PKSA-m5cs-t1y6-qpcs`, `PKSA-3r5d-mb8f-1qw9`) are missing from `config.audit.ignore`, so `composer require laravel/framework:^11.0` no longer resolves and the **P8.2/P8.3 - L^11.0** legs fail to install.

This adds both IDs next to the existing five 11.x ignores (root CI config only; does not propagate to host apps).

Unblocks the red `L^11` legs on main and on the open dependabot PRs #138, #139, #140, #141.